### PR TITLE
PR-8 + PR-11: structured JSON error envelope with stable error code registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 *.out
 *.cov
 .DS_Store
+
+# Built binaries (never commit)
+cmd/secretgenerator/secretgenerator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Structured error output in `--json` mode. When generation fails, the CLI
+  emits a schema-v1 envelope with a populated `error` object containing a
+  stable `code` (`E_INVALID_ARGS`, `E_ENTROPY_TOO_LOW`, `E_RNG_FAILURE`,
+  `E_CHARSET_EMPTY`, `E_CLASS_IMPOSSIBLE`), an English `message`, and an
+  optional curated `hint` with one-line remediation. Stderr stays silent
+  in JSON mode so agents see exactly one machine-readable artifact.
+  Plain mode (without `--json`) keeps the legacy stderr+exit-code
+  behavior unchanged.
+- `error` field added to `schemas/output-v1.json` (additive, non-breaking).
+- `audit.NewError` and the `Error` struct in `internal/audit` for
+  programmatic construction.
+- E2E coverage for every error path under `--json`.
+
 ## [2.0.0] — 2026-04-29
 
 This is a complete rewrite of secretgenerator into an auditable standard for

--- a/cmd/secretgenerator/apikey.go
+++ b/cmd/secretgenerator/apikey.go
@@ -71,32 +71,33 @@ Default length 32 base62 characters yields ~190 bits of entropy.`,
 }
 
 func runAPIKey(o apiKeyOptions) error {
+	e := errCtx{c: o.commonOpts, subcommand: "api-key"}
 	if o.StdinParams {
 		req, err := readStdinAPIKeyParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinAPIKey(&o, req)
 	}
 	if o.Prefix == "" {
-		return fail(ExitInvalidArgs, fmt.Errorf("prefix must not be empty"))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("prefix must not be empty"))
 	}
 	if strings.ContainsAny(o.Prefix, " \t\n\r") {
-		return fail(ExitInvalidArgs, fmt.Errorf("prefix must not contain whitespace"))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("prefix must not contain whitespace"))
 	}
 	if o.Length <= 0 {
-		return fail(ExitInvalidArgs, fmt.Errorf("length must be > 0, got %d", o.Length))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("length must be > 0, got %d", o.Length))
 	}
 
 	cs, err := charset.Get("base62-v1")
 	if err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 
 	bits := policy.EntropyBits(o.Length, cs.Size())
 	var warnings []string
 	if floorErr := policy.EnforceFloor(bits, o.MinEntropyBits, o.AllowWeak); floorErr != nil {
-		return fail(ExitEntropyTooLow, floorErr)
+		return e.fail(ExitEntropyTooLow, floorErr)
 	}
 	if o.MinEntropyBits > 0 && bits < o.MinEntropyBits && o.AllowWeak {
 		warnings = append(warnings,
@@ -108,7 +109,7 @@ func runAPIKey(o apiKeyOptions) error {
 		Length:  o.Length,
 	})
 	if err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 	token := o.Prefix + o.Separator + body
 
@@ -121,7 +122,7 @@ func runAPIKey(o apiKeyOptions) error {
 		Subcommand:  "api-key",
 		Warnings:    warnings,
 	}
-	return emit(o.commonOpts, out, token)
+	return emit(e, out, token)
 }
 
 func readStdinAPIKeyParams(r io.Reader) (stdinAPIKeyRequest, error) {

--- a/cmd/secretgenerator/entropy.go
+++ b/cmd/secretgenerator/entropy.go
@@ -88,25 +88,40 @@ password (the caller already has it).`,
 }
 
 func runEntropy(o entropyOptions) error {
+	// Synthesize a minimal commonOpts-compatible context for error
+	// reporting, since entropy has its own option struct rather than
+	// embedding commonOpts.
+	e := errCtx{
+		c: commonOpts{
+			JSON:   o.JSON,
+			stdin:  o.stdin,
+			stdout: o.stdout,
+			stderr: o.stderr,
+			now:    o.now,
+			uuid:   o.uuid,
+		},
+		subcommand: "entropy",
+	}
+
 	if o.RequireSchemaVersion != 0 && o.RequireSchemaVersion != audit.SchemaVersion {
-		return fail(ExitInvalidArgs, fmt.Errorf("require-schema-version=%d, but binary emits schema %d",
+		return e.fail(ExitInvalidArgs, fmt.Errorf("require-schema-version=%d, but binary emits schema %d",
 			o.RequireSchemaVersion, audit.SchemaVersion))
 	}
 	if o.StdinParams {
 		req, err := readStdinEntropyParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinEntropy(&o, req)
 	} else if o.Password == "" {
 		pw, err := readStdinPassword(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		o.Password = pw
 	}
 	if o.Password == "" {
-		return fail(ExitInvalidArgs, fmt.Errorf("entropy: empty password"))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("entropy: empty password"))
 	}
 
 	classes := observeClasses(o.Password)
@@ -122,7 +137,7 @@ func runEntropy(o entropyOptions) error {
 	if o.JSON {
 		requestID, err := o.uuid()
 		if err != nil {
-			return fail(ExitRNGFailure, fmt.Errorf("request id: %w", err))
+			return e.fail(ExitRNGFailure, fmt.Errorf("request id: %w", err))
 		}
 		out := audit.Output{
 			SchemaVersion:   audit.SchemaVersion,
@@ -147,7 +162,7 @@ func runEntropy(o entropyOptions) error {
 	}
 
 	if _, err := fmt.Fprintf(o.stdout, "%.2f bits\n", bits); err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 	if o.ShowCrackTime {
 		printCrackTime(o.stdout, bits)

--- a/cmd/secretgenerator/exit.go
+++ b/cmd/secretgenerator/exit.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/rafaelperoco/secretgenerator/internal/audit"
+
 // Exit codes form part of the CLI public contract. Documented in
 // docs/SCHEMA.md and tested in test/e2e.
 const (
@@ -11,10 +13,38 @@ const (
 	ExitClassImpossible = 6
 )
 
+// exitToCode maps the process exit code to the stable string identifier
+// used in JSON error envelopes. Agents should branch on the string code
+// (E_INVALID_ARGS, etc.) rather than the integer because the strings
+// survive future exit-code reshuffles and double as keys into the hint
+// table maintained in internal/audit.
+func exitToCode(exit int) string {
+	switch exit {
+	case ExitInvalidArgs:
+		return audit.CodeInvalidArgs
+	case ExitEntropyTooLow:
+		return audit.CodeEntropyTooLow
+	case ExitRNGFailure:
+		return audit.CodeRNGFailure
+	case ExitCharsetEmpty:
+		return audit.CodeCharsetEmpty
+	case ExitClassImpossible:
+		return audit.CodeClassImpossible
+	}
+	return audit.CodeInvalidArgs
+}
+
 // codedError pairs a process exit code with an error.
+//
+// When jsonEmitted is true, the failing subcommand has already written a
+// schema-v1 JSON error envelope to stdout. main() then suppresses the
+// default "fmt.Fprintln(stderr, err)" path so the agent sees only the
+// structured JSON (the integer exit code is still propagated for
+// shell-script callers).
 type codedError struct {
-	code int
-	err  error
+	code        int
+	err         error
+	jsonEmitted bool
 }
 
 func (e *codedError) Error() string {
@@ -31,4 +61,14 @@ func fail(code int, err error) error {
 		return nil
 	}
 	return &codedError{code: code, err: err}
+}
+
+// failJSON is the variant subcommands use when they have already emitted a
+// JSON error envelope on stdout. main() will not echo the message to
+// stderr.
+func failJSON(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &codedError{code: code, err: err, jsonEmitted: true}
 }

--- a/cmd/secretgenerator/main.go
+++ b/cmd/secretgenerator/main.go
@@ -9,11 +9,17 @@ import (
 
 func main() {
 	if err := newRootCmd().Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		var ce *codedError
 		if errors.As(err, &ce) {
+			// When the subcommand already emitted a structured JSON
+			// error envelope on stdout, do not duplicate the message on
+			// stderr — the agent has the structured form already.
+			if !ce.jsonEmitted {
+				fmt.Fprintln(os.Stderr, err)
+			}
 			os.Exit(ce.code)
 		}
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(ExitInvalidArgs)
 	}
 }

--- a/cmd/secretgenerator/passphrase.go
+++ b/cmd/secretgenerator/passphrase.go
@@ -89,18 +89,19 @@ entropy at the seam) and works in shells, URLs, env files, and JSON.`,
 }
 
 func runPassphrase(o passphraseOptions) error {
+	e := errCtx{c: o.commonOpts, subcommand: "passphrase"}
 	if o.StdinParams {
 		req, err := readStdinPassphraseParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinPassphrase(&o, req)
 	}
 	if o.Words <= 0 {
-		return fail(ExitInvalidArgs, fmt.Errorf("words must be > 0, got %d", o.Words))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("words must be > 0, got %d", o.Words))
 	}
 	if o.Separator == "" {
-		return fail(ExitInvalidArgs,
+		return e.fail(ExitInvalidArgs,
 			fmt.Errorf("separator must not be empty (without a separator, adjacent words can fuse, leaking entropy at boundaries)"))
 	}
 
@@ -113,7 +114,7 @@ func runPassphrase(o passphraseOptions) error {
 
 	var warnings []string
 	if err := policy.EnforceFloor(bits, o.MinEntropyBits, o.AllowWeak); err != nil {
-		return fail(ExitEntropyTooLow, err)
+		return e.fail(ExitEntropyTooLow, err)
 	}
 	if o.MinEntropyBits > 0 && bits < o.MinEntropyBits && o.AllowWeak {
 		warnings = append(warnings,
@@ -130,7 +131,7 @@ func runPassphrase(o passphraseOptions) error {
 
 	picked, err := words.PickEFFLarge(o.Words, nil)
 	if err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 	if o.Capitalize {
 		for i, w := range picked {
@@ -141,7 +142,7 @@ func runPassphrase(o passphraseOptions) error {
 	if o.DigitSuffix {
 		d, err := pickDigit()
 		if err != nil {
-			return fail(ExitRNGFailure, err)
+			return e.fail(ExitRNGFailure, err)
 		}
 		phrase += d
 	}
@@ -155,7 +156,7 @@ func runPassphrase(o passphraseOptions) error {
 		Subcommand:  "passphrase",
 		Warnings:    warnings,
 	}
-	return emit(o.commonOpts, out, phrase)
+	return emit(e, out, phrase)
 }
 
 func capitalizeFirst(s string) string {

--- a/cmd/secretgenerator/pin.go
+++ b/cmd/secretgenerator/pin.go
@@ -69,25 +69,26 @@ limits (banking, hardware tokens) — never as a primary authenticator.`,
 }
 
 func runPIN(o pinOptions) error {
+	e := errCtx{c: o.commonOpts, subcommand: "pin"}
 	if o.StdinParams {
 		req, err := readStdinPINParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinPIN(&o, req)
 	}
 	if o.Digits < 4 {
-		return fail(ExitInvalidArgs, fmt.Errorf("digits must be >= 4, got %d", o.Digits))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("digits must be >= 4, got %d", o.Digits))
 	}
 	if !o.AcknowledgeLowEntropy {
-		return fail(ExitEntropyTooLow,
+		return e.fail(ExitEntropyTooLow,
 			fmt.Errorf("PIN generation requires --acknowledge-low-entropy (PINs carry %0.1f bits, far below any password floor)",
 				policy.EntropyBits(o.Digits, 10)))
 	}
 
 	cs, err := charset.Get("digit-v1")
 	if err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 
 	var pin string
@@ -97,14 +98,14 @@ func runPIN(o pinOptions) error {
 			Length:  o.Digits,
 		})
 		if gerr != nil {
-			return fail(ExitRNGFailure, gerr)
+			return e.fail(ExitRNGFailure, gerr)
 		}
 		if o.AllowWeakPattern || !policy.IsWeakPIN(candidate) {
 			pin = candidate
 			break
 		}
 		if attempt == MaxPINRejectionRetries-1 {
-			return fail(ExitRNGFailure,
+			return e.fail(ExitRNGFailure,
 				fmt.Errorf("could not produce a strong-pattern PIN after %d attempts", MaxPINRejectionRetries))
 		}
 	}
@@ -121,7 +122,7 @@ func runPIN(o pinOptions) error {
 			fmt.Sprintf("PIN entropy is %.1f bits; safe only with verifier-side rate limiting", bits),
 		},
 	}
-	return emit(o.commonOpts, out, pin)
+	return emit(e, out, pin)
 }
 
 func readStdinPINParams(r io.Reader) (stdinPINRequest, error) {

--- a/cmd/secretgenerator/root.go
+++ b/cmd/secretgenerator/root.go
@@ -99,17 +99,18 @@ automated systems that need verifiable provenance for generated secrets.`
 }
 
 func runPassword(o runOptions) error {
+	e := errCtx{c: o.commonOpts, subcommand: "password"}
 	if o.StdinParams {
 		req, err := readStdinPasswordParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinPassword(&o, req)
 	}
 
 	cs, err := charset.Get(o.CharsetID)
 	if err != nil {
-		return fail(ExitInvalidArgs, err)
+		return e.fail(ExitInvalidArgs, err)
 	}
 
 	excludedCount := 0
@@ -120,22 +121,22 @@ func runPassword(o runOptions) error {
 		excludedSHA = audit.SHA256Hex(o.Exclude)
 		cs, err = charset.Exclude(cs, excludedRunes)
 		if err != nil {
-			return fail(ExitCharsetEmpty, err)
+			return e.fail(ExitCharsetEmpty, err)
 		}
 	}
 
 	requiredClasses, err := policy.ParseClasses(o.RequiredClassesSpec)
 	if err != nil {
-		return fail(ExitInvalidArgs, err)
+		return e.fail(ExitInvalidArgs, err)
 	}
 	if validateErr := policy.ValidateClassesAchievable(cs, o.Length, requiredClasses); validateErr != nil {
-		return fail(ExitClassImpossible, validateErr)
+		return e.fail(ExitClassImpossible, validateErr)
 	}
 
 	bits := policy.EntropyBits(o.Length, cs.Size())
 	var warnings []string
 	if floorErr := policy.EnforceFloor(bits, o.MinEntropyBits, o.AllowWeak); floorErr != nil {
-		return fail(ExitEntropyTooLow, floorErr)
+		return e.fail(ExitEntropyTooLow, floorErr)
 	}
 	if o.MinEntropyBits > 0 && bits < o.MinEntropyBits && o.AllowWeak {
 		warnings = append(warnings,
@@ -149,9 +150,9 @@ func runPassword(o runOptions) error {
 	})
 	if err != nil {
 		if errors.Is(err, generator.ErrClassExhausted) {
-			return fail(ExitClassImpossible, err)
+			return e.fail(ExitClassImpossible, err)
 		}
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 
 	out := audit.Output{
@@ -167,7 +168,7 @@ func runPassword(o runOptions) error {
 		Warnings:        warnings,
 	}
 
-	return emit(o.commonOpts, out, pw)
+	return emit(e, out, pw)
 }
 
 func writeJSON(w io.Writer, out audit.Output) error {

--- a/cmd/secretgenerator/runner.go
+++ b/cmd/secretgenerator/runner.go
@@ -51,16 +51,19 @@ func addCommonFlags(cmd *cobra.Command, o *commonOpts) {
 
 // emit stamps the audit envelope and writes the result. Each subcommand
 // constructs an audit.Output with its own subcommand-specific fields and
-// hands it here for finalization.
-func emit(c commonOpts, out audit.Output, password string) error {
+// hands it here for finalization. Errors emitted from inside emit() use
+// the supplied errCtx so they get the same structured-JSON treatment as
+// errors emitted from the validation path before emit() was called.
+func emit(e errCtx, out audit.Output, password string) error {
+	c := e.c
 	if c.RequireSchemaVersion != 0 && c.RequireSchemaVersion != audit.SchemaVersion {
-		return fail(ExitInvalidArgs, fmt.Errorf("require-schema-version=%d, but binary emits schema %d",
+		return e.fail(ExitInvalidArgs, fmt.Errorf("require-schema-version=%d, but binary emits schema %d",
 			c.RequireSchemaVersion, audit.SchemaVersion))
 	}
 
 	requestID, err := c.uuid()
 	if err != nil {
-		return fail(ExitRNGFailure, fmt.Errorf("request id: %w", err))
+		return e.fail(ExitRNGFailure, fmt.Errorf("request id: %w", err))
 	}
 	out.SchemaVersion = audit.SchemaVersion
 	out.Password = password
@@ -75,8 +78,8 @@ func emit(c commonOpts, out audit.Output, password string) error {
 
 	if c.AuditLogPath != "" {
 		entry := audit.LogFromOutput(out, audit.SHA256Hex(password))
-		if err := audit.AppendLog(c.AuditLogPath, entry); err != nil {
-			return fail(ExitInvalidArgs, err)
+		if appendErr := audit.AppendLog(c.AuditLogPath, entry); appendErr != nil {
+			return e.fail(ExitInvalidArgs, appendErr)
 		}
 	}
 
@@ -84,12 +87,56 @@ func emit(c commonOpts, out audit.Output, password string) error {
 		return writeJSON(c.stdout, out)
 	}
 	if _, err := fmt.Fprintln(c.stdout, password); err != nil {
-		return fail(ExitRNGFailure, err)
+		return e.fail(ExitRNGFailure, err)
 	}
 	if c.ShowCrackTime {
 		printCrackTime(c.stdout, out.EntropyBits)
 	}
 	return nil
+}
+
+// errCtx is the context a subcommand needs to emit a structured JSON
+// error envelope. Subcommands construct one near the top of their run
+// function (where commonOpts and the subcommand name are both in scope)
+// and call .fail(exitCode, err) instead of the global fail() in error
+// paths. In --json mode this writes a schema-v1 envelope to stdout;
+// otherwise it falls through to the legacy stderr behavior in main().
+type errCtx struct {
+	c          commonOpts
+	subcommand string
+}
+
+func (e errCtx) fail(exitCode int, err error) error {
+	if !e.c.JSON {
+		return fail(exitCode, err)
+	}
+	if err == nil {
+		return nil
+	}
+
+	requestID, idErr := e.c.uuid()
+	if idErr != nil {
+		// Fall back to a synthetic placeholder so the envelope is still
+		// well-formed; the agent can correlate via timestamp.
+		requestID = "00000000-0000-4000-8000-000000000000"
+	}
+
+	out := audit.Output{
+		SchemaVersion: audit.SchemaVersion,
+		Subcommand:    e.subcommand,
+		Version:       version,
+		Commit:        commit,
+		BuildDate:     buildDate,
+		RequestID:     requestID,
+		TimestampUTC:  e.c.now().Format(time.RFC3339Nano),
+		Error:         audit.NewError(exitToCode(exitCode), err.Error()),
+	}
+	if writeErr := writeJSON(e.c.stdout, out); writeErr != nil {
+		// If we cannot even write to stdout, fall back to legacy stderr
+		// so the agent at least gets *something*.
+		return fail(exitCode, err)
+	}
+	return failJSON(exitCode, err)
 }
 
 // projectCrackTimes converts policy.CrackTimeEstimate values into the

--- a/cmd/secretgenerator/runner_test.go
+++ b/cmd/secretgenerator/runner_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rafaelperoco/secretgenerator/internal/audit"
+)
+
+// errCtxOpts builds a minimal errCtx with a deterministic uuid/now and a
+// captured stdout buffer for assertions.
+func errCtxOpts(t *testing.T, jsonMode bool) (errCtx, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	c := commonOpts{
+		JSON:   jsonMode,
+		stdout: &buf,
+		now:    func() time.Time { return time.Date(2026, 5, 2, 22, 0, 0, 0, time.UTC) },
+		uuid:   func() (string, error) { return "11111111-2222-4333-8444-555555555555", nil },
+	}
+	return errCtx{c: c, subcommand: "password"}, &buf
+}
+
+func TestErrCtx_PlainModeFallsThrough(t *testing.T) {
+	e, buf := errCtxOpts(t, false)
+	err := e.fail(ExitInvalidArgs, errors.New("synthetic"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("plain mode should not write to stdout, got %q", buf.String())
+	}
+	var ce *codedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *codedError, got %T", err)
+	}
+	if ce.code != ExitInvalidArgs {
+		t.Errorf("code = %d", ce.code)
+	}
+	if ce.jsonEmitted {
+		t.Errorf("plain mode must not set jsonEmitted")
+	}
+}
+
+func TestErrCtx_JSONModeEmitsEnvelope(t *testing.T) {
+	e, buf := errCtxOpts(t, true)
+	err := e.fail(ExitEntropyTooLow, errors.New("policy: entropy below floor"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ce *codedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected *codedError, got %T", err)
+	}
+	if !ce.jsonEmitted {
+		t.Errorf("JSON mode must set jsonEmitted")
+	}
+	if ce.code != ExitEntropyTooLow {
+		t.Errorf("code = %d, want %d", ce.code, ExitEntropyTooLow)
+	}
+
+	var out audit.Output
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v\n%s", err, buf.String())
+	}
+	if out.SchemaVersion != audit.SchemaVersion {
+		t.Errorf("schema_version = %d", out.SchemaVersion)
+	}
+	if out.Error == nil {
+		t.Fatalf("error field missing")
+	}
+	if out.Error.Code != audit.CodeEntropyTooLow {
+		t.Errorf("error.code = %q, want %q", out.Error.Code, audit.CodeEntropyTooLow)
+	}
+	if out.Error.Hint == "" {
+		t.Errorf("error.hint should be populated for known code")
+	}
+	if out.Subcommand != "password" {
+		t.Errorf("subcommand = %q", out.Subcommand)
+	}
+	if out.RequestID == "" {
+		t.Errorf("request_id missing")
+	}
+	if out.TimestampUTC == "" {
+		t.Errorf("timestamp_utc missing")
+	}
+	if out.Password != "" {
+		t.Errorf("password should not be present on failure path")
+	}
+}
+
+func TestErrCtx_NilError(t *testing.T) {
+	e, _ := errCtxOpts(t, true)
+	if got := e.fail(ExitInvalidArgs, nil); got != nil {
+		t.Errorf("nil error should yield nil, got %v", got)
+	}
+}
+
+func TestErrCtx_UUIDFailureUsesPlaceholder(t *testing.T) {
+	var buf bytes.Buffer
+	c := commonOpts{
+		JSON:   true,
+		stdout: &buf,
+		now:    func() time.Time { return time.Date(2026, 5, 2, 22, 0, 0, 0, time.UTC) },
+		uuid:   func() (string, error) { return "", errors.New("synthetic uuid failure") },
+	}
+	e := errCtx{c: c, subcommand: "secret"}
+	err := e.fail(ExitRNGFailure, errors.New("rng down"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var out audit.Output
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.RequestID != "00000000-0000-4000-8000-000000000000" {
+		t.Errorf("request_id placeholder = %q", out.RequestID)
+	}
+	if out.Subcommand != "secret" {
+		t.Errorf("subcommand = %q", out.Subcommand)
+	}
+}
+
+type failingWriter2 struct{ err error }
+
+func (f failingWriter2) Write(_ []byte) (int, error) { return 0, f.err }
+
+func TestErrCtx_StdoutWriteFailureFallsBackToLegacy(t *testing.T) {
+	c := commonOpts{
+		JSON:   true,
+		stdout: failingWriter2{err: errors.New("write closed")},
+		now:    func() time.Time { return time.Now().UTC() },
+		uuid:   func() (string, error) { return "11111111-2222-4333-8444-555555555555", nil },
+	}
+	e := errCtx{c: c, subcommand: "password"}
+	err := e.fail(ExitCharsetEmpty, errors.New("empty"))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var ce *codedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected codedError")
+	}
+	if ce.jsonEmitted {
+		t.Errorf("must not claim JSON emitted when stdout write failed")
+	}
+	if ce.code != ExitCharsetEmpty {
+		t.Errorf("code = %d", ce.code)
+	}
+}
+
+func TestExitToCode_AllKnownCodes(t *testing.T) {
+	tests := map[int]string{
+		ExitInvalidArgs:     audit.CodeInvalidArgs,
+		ExitEntropyTooLow:   audit.CodeEntropyTooLow,
+		ExitRNGFailure:      audit.CodeRNGFailure,
+		ExitCharsetEmpty:    audit.CodeCharsetEmpty,
+		ExitClassImpossible: audit.CodeClassImpossible,
+		// Unknown integer falls back to E_INVALID_ARGS as a safe default.
+		999: audit.CodeInvalidArgs,
+	}
+	for input, want := range tests {
+		if got := exitToCode(input); got != want {
+			t.Errorf("exitToCode(%d) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestFailJSON_NilError(t *testing.T) {
+	if got := failJSON(ExitInvalidArgs, nil); got != nil {
+		t.Errorf("failJSON(_, nil) = %v, want nil", got)
+	}
+}
+
+func TestFailJSON_SetsJSONEmittedFlag(t *testing.T) {
+	err := failJSON(ExitRNGFailure, errors.New("boom"))
+	var ce *codedError
+	if !errors.As(err, &ce) {
+		t.Fatalf("expected codedError")
+	}
+	if !ce.jsonEmitted {
+		t.Errorf("failJSON must set jsonEmitted=true")
+	}
+	if ce.code != ExitRNGFailure {
+		t.Errorf("code = %d", ce.code)
+	}
+	if !strings.Contains(ce.Error(), "boom") {
+		t.Errorf("error wraps message: %v", ce.Error())
+	}
+}

--- a/cmd/secretgenerator/secret.go
+++ b/cmd/secretgenerator/secret.go
@@ -71,25 +71,26 @@ URLs, HTTP headers, environment variables, and JSON payloads.`,
 }
 
 func runSecret(o secretOptions) error {
+	e := errCtx{c: o.commonOpts, subcommand: "secret"}
 	if o.StdinParams {
 		req, err := readStdinSecretParams(o.stdin)
 		if err != nil {
-			return fail(ExitInvalidArgs, err)
+			return e.fail(ExitInvalidArgs, err)
 		}
 		applyStdinSecret(&o, req)
 	}
 
 	if o.Bytes <= 0 {
-		return fail(ExitInvalidArgs, fmt.Errorf("bytes must be > 0, got %d", o.Bytes))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("bytes must be > 0, got %d", o.Bytes))
 	}
 	if !validEncoding(o.Encoding) {
-		return fail(ExitInvalidArgs, fmt.Errorf("unknown encoding %q (want base64url, base64, base32, hex)", o.Encoding))
+		return e.fail(ExitInvalidArgs, fmt.Errorf("unknown encoding %q (want base64url, base64, base32, hex)", o.Encoding))
 	}
 
 	bits := float64(o.Bytes) * 8
 	var warnings []string
 	if err := policy.EnforceFloor(bits, o.MinEntropyBits, o.AllowWeak); err != nil {
-		return fail(ExitEntropyTooLow, err)
+		return e.fail(ExitEntropyTooLow, err)
 	}
 	if o.MinEntropyBits > 0 && bits < o.MinEntropyBits && o.AllowWeak {
 		warnings = append(warnings,
@@ -98,7 +99,7 @@ func runSecret(o secretOptions) error {
 
 	raw := make([]byte, o.Bytes)
 	if _, err := io.ReadFull(rand.Reader, raw); err != nil {
-		return fail(ExitRNGFailure, fmt.Errorf("entropy source: %w", err))
+		return e.fail(ExitRNGFailure, fmt.Errorf("entropy source: %w", err))
 	}
 	encoded := encode(raw, o.Encoding)
 	zeroize(raw)
@@ -113,7 +114,7 @@ func runSecret(o secretOptions) error {
 		Subcommand:  "secret",
 		Warnings:    warnings,
 	}
-	return emit(o.commonOpts, out, secret)
+	return emit(e, out, secret)
 }
 
 func validEncoding(e string) bool {

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -51,6 +51,7 @@ schema version.
 | `required_classes`     | string  | Comma-separated list of character classes the output is guaranteed to contain (or, for `entropy`, observed in the input).                  |
 | `warnings`             | array   | Strings describing non-fatal advisories (e.g. when `--allow-weak` bypassed the floor or when a compatibility flag was used).               |
 | `crack_time_estimates` | array   | Opt-in (set with `--show-crack-time`). Time-to-break estimates under named attacker profiles.                                              |
+| `error`                | object  | Present only on the failure path. Carries a stable `code` (e.g. `E_ENTROPY_TOO_LOW`), an English `message`, and an optional curated `hint`. |
 
 ### Audit log additions
 
@@ -94,6 +95,44 @@ requires bumping the suffix. The five profiles span 13 orders of magnitude:
 These are estimates. Real-world cracking depends on the specific KDF, the
 size of the search space the attacker actually explores (dictionaries vs.
 brute force), and hardware availability.
+
+## error (failure path)
+
+When `--json` is set and the requested generation cannot be produced, the
+CLI writes a schema-v1 envelope with a populated `error` object to stdout
+and exits with the matching integer code. Stderr is silent in JSON mode so
+agents see exactly one machine-readable artifact.
+
+Codes are stable strings; agents should branch on these rather than parse
+the message or rely on integer exit codes:
+
+| code                  | exit | meaning                                                                                              |
+| --------------------- | ---: | ---------------------------------------------------------------------------------------------------- |
+| `E_INVALID_ARGS`      |    2 | Unknown flag, unknown charset, schema-version mismatch, audit-log write failure, malformed stdin     |
+| `E_ENTROPY_TOO_LOW`   |    3 | Computed entropy is below `--min-entropy-bits` and `--allow-weak` was not set                        |
+| `E_RNG_FAILURE`       |    4 | OS entropy source returned an error mid-generation                                                   |
+| `E_CHARSET_EMPTY`     |    5 | `--exclude` reduced the charset below the minimum 2 runes                                            |
+| `E_CLASS_IMPOSSIBLE`  |    6 | `--require-classes` cannot be satisfied (charset lacks the class, or length < class count)           |
+
+Each code has a curated one-line `hint` documenting the typical fix.
+Hints are advisory and may be empty for codes added in future versions.
+
+```json
+{
+  "schema_version": 1,
+  "subcommand": "password",
+  "version": "v2.0.0",
+  "commit": "abc1234",
+  "build_date": "2026-05-02T22:00:00Z",
+  "request_id": "8a7f...-...-...",
+  "timestamp_utc": "2026-05-02T22:01:33Z",
+  "error": {
+    "code": "E_ENTROPY_TOO_LOW",
+    "message": "policy: entropy below floor: 23.82 bits < floor 80.00",
+    "hint": "increase --length, choose a richer --charset, or pass --allow-weak (records a warning)"
+  }
+}
+```
 
 ## Example
 

--- a/internal/audit/errors.go
+++ b/internal/audit/errors.go
@@ -1,0 +1,48 @@
+package audit
+
+// Error code registry. These string identifiers are stable and versioned
+// in lockstep with the CLI's exit codes. Agents should branch on Code
+// rather than on the integer exit code, both because string codes survive
+// a future exit-code reshuffle and because they double as a key into the
+// hint table below.
+//
+// Keep this list in sync with cmd/secretgenerator/exit.go and with
+// docs/SCHEMA.md. New codes are additive (non-breaking); changing the
+// meaning of an existing code is breaking.
+const (
+	CodeInvalidArgs     = "E_INVALID_ARGS"
+	CodeEntropyTooLow   = "E_ENTROPY_TOO_LOW"
+	CodeRNGFailure      = "E_RNG_FAILURE"
+	CodeCharsetEmpty    = "E_CHARSET_EMPTY"
+	CodeClassImpossible = "E_CLASS_IMPOSSIBLE"
+)
+
+// hints maps a stable error code to a one-line remediation suggestion. The
+// hint is intentionally short and prescriptive — it tells the caller what
+// to change to recover, not why the error happened. Used by the CLI to
+// populate Error.Hint.
+var hints = map[string]string{
+	CodeInvalidArgs:     "check argument names and types; run `--help` to see the accepted shape",
+	CodeEntropyTooLow:   "increase --length, choose a richer --charset, or pass --allow-weak (records a warning)",
+	CodeRNGFailure:      "the OS entropy source returned an error; retry, and check that /dev/urandom or the equivalent is reachable",
+	CodeCharsetEmpty:    "--exclude removed too many runes; relax the exclusion or pick a larger --charset",
+	CodeClassImpossible: "--require-classes asks for a class the --charset cannot supply, or --length is shorter than the number of classes; pick a richer charset or longer length",
+}
+
+// HintFor returns the curated hint for a known error code, or empty string
+// if the code is not in the registry. Callers may use this directly when
+// constructing Error{} values.
+func HintFor(code string) string {
+	return hints[code]
+}
+
+// NewError is a small constructor used by the CLI fail() helper. It looks
+// up the hint from the registry; callers can override by setting Hint
+// after construction.
+func NewError(code, message string) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+		Hint:    hints[code],
+	}
+}

--- a/internal/audit/errors_test.go
+++ b/internal/audit/errors_test.go
@@ -1,0 +1,44 @@
+package audit
+
+import "testing"
+
+func TestNewError_KnownCode(t *testing.T) {
+	e := NewError(CodeEntropyTooLow, "policy: 23.82 bits < 80")
+	if e.Code != CodeEntropyTooLow {
+		t.Errorf("Code = %q, want %q", e.Code, CodeEntropyTooLow)
+	}
+	if e.Message != "policy: 23.82 bits < 80" {
+		t.Errorf("Message = %q", e.Message)
+	}
+	if e.Hint == "" {
+		t.Errorf("Hint should be populated for known code")
+	}
+}
+
+func TestNewError_UnknownCode(t *testing.T) {
+	e := NewError("E_DOES_NOT_EXIST", "synthetic")
+	if e.Code != "E_DOES_NOT_EXIST" {
+		t.Errorf("Code = %q", e.Code)
+	}
+	if e.Hint != "" {
+		t.Errorf("Hint should be empty for unknown code, got %q", e.Hint)
+	}
+}
+
+func TestHintFor_Coverage(t *testing.T) {
+	codes := []string{
+		CodeInvalidArgs,
+		CodeEntropyTooLow,
+		CodeRNGFailure,
+		CodeCharsetEmpty,
+		CodeClassImpossible,
+	}
+	for _, c := range codes {
+		if HintFor(c) == "" {
+			t.Errorf("registry missing hint for %q", c)
+		}
+	}
+	if HintFor("E_NOPE") != "" {
+		t.Errorf("HintFor(unknown) should return empty string")
+	}
+}

--- a/internal/audit/schema.go
+++ b/internal/audit/schema.go
@@ -20,19 +20,42 @@ type CrackTimeEstimate struct {
 	HumanReadable string  `json:"human_readable"`
 }
 
-// Output is the JSON document emitted on stdout when --json is set, and
+// Error is the structured failure shape emitted in JSON mode when the CLI
+// cannot produce a credential. Adding this field is additive and stays
+// within schema-v1: pre-existing consumers that ignore unknown fields are
+// unaffected.
+//
+// Code is a stable, versioned string identifier (E_INVALID_ARGS,
+// E_ENTROPY_TOO_LOW, E_RNG_FAILURE, E_CHARSET_EMPTY, E_CLASS_IMPOSSIBLE).
+// Agents should branch on Code rather than parsing Message, which is
+// English prose intended for human consumption. Hint is a one-line
+// remediation suggestion in the same prose register as Message; consumers
+// are free to ignore it.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Hint    string `json:"hint,omitempty"`
+}
+
+// Output is the JSON document emitted on stdout when --json is set. It is
 // also the basis (with the password redacted) for an audit-log entry.
+//
+// On the success path Error is nil and Password/Length/CharsetID/etc. are
+// populated. On the failure path Error is populated and Password is empty;
+// the build-identity fields (Version, Commit, BuildDate, RequestID,
+// TimestampUTC, Subcommand) are always set so consumers can correlate the
+// failure with a specific binary version and an audit log entry.
 type Output struct {
 	SchemaVersion      int                 `json:"schema_version"`
 	Password           string              `json:"password,omitempty"`
-	Length             int                 `json:"length"`
-	CharsetID          string              `json:"charset_id"`
-	CharsetSize        int                 `json:"charset_size"`
-	EntropyBits        float64             `json:"entropy_bits"`
-	ExcludedCount      int                 `json:"excluded_count"`
+	Length             int                 `json:"length,omitempty"`
+	CharsetID          string              `json:"charset_id,omitempty"`
+	CharsetSize        int                 `json:"charset_size,omitempty"`
+	EntropyBits        float64             `json:"entropy_bits,omitempty"`
+	ExcludedCount      int                 `json:"excluded_count,omitempty"`
 	ExcludedSHA256     string              `json:"excluded_sha256,omitempty"`
 	RequiredClasses    string              `json:"required_classes,omitempty"`
-	Algorithm          string              `json:"algorithm"`
+	Algorithm          string              `json:"algorithm,omitempty"`
 	Subcommand         string              `json:"subcommand"`
 	Version            string              `json:"version"`
 	Commit             string              `json:"commit"`
@@ -41,6 +64,7 @@ type Output struct {
 	TimestampUTC       string              `json:"timestamp_utc"`
 	Warnings           []string            `json:"warnings,omitempty"`
 	CrackTimeEstimates []CrackTimeEstimate `json:"crack_time_estimates,omitempty"`
+	Error              *Error              `json:"error,omitempty"`
 }
 
 // LogEntry is the redacted form written to the audit log file. It is

--- a/schemas/output-v1.json
+++ b/schemas/output-v1.json
@@ -111,6 +111,33 @@
           "human_readable": { "type": "string" }
         }
       }
+    },
+    "error": {
+      "description": "Present only on the failure path when --json is set. Successful generations omit this field. The CLI exits with the integer exit code corresponding to the string code; agents should branch on the string code, which is stable across exit-code reshuffles. When error is present, the password / length / charset_id / charset_size / entropy_bits / algorithm fields are typically absent (the credential was not produced); the build-identity fields (subcommand, version, commit, build_date, request_id, timestamp_utc) remain populated for audit correlation.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "description": "Stable string identifier. Agents should branch on this rather than parse the message.",
+          "type": "string",
+          "enum": [
+            "E_INVALID_ARGS",
+            "E_ENTROPY_TOO_LOW",
+            "E_RNG_FAILURE",
+            "E_CHARSET_EMPTY",
+            "E_CLASS_IMPOSSIBLE"
+          ]
+        },
+        "message": {
+          "description": "English prose describing the failure. Intended for human consumption; not stable.",
+          "type": "string"
+        },
+        "hint": {
+          "description": "One-line remediation suggestion. May be empty if no curated hint is registered for the code.",
+          "type": "string"
+        }
+      }
     }
   }
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -354,6 +354,99 @@ func TestE2E_SecretEncodings(t *testing.T) {
 	}
 }
 
+// TestE2E_StructuredErrorsInJSON verifies that every error path emits a
+// schema-v1 JSON envelope with a populated Error field when --json is set,
+// rather than plain prose on stderr. Agents branch on the stable string
+// code (E_INVALID_ARGS, etc.) rather than the integer exit code.
+func TestE2E_StructuredErrorsInJSON(t *testing.T) {
+	cases := []struct {
+		name     string
+		args     []string
+		exitCode int
+		wantCode string
+	}{
+		{
+			name:     "invalid charset",
+			args:     []string{"--json", "--charset", "no-such"},
+			exitCode: exitInvalidArgs,
+			wantCode: "E_INVALID_ARGS",
+		},
+		{
+			name:     "entropy too low",
+			args:     []string{"--json", "--length", "4"},
+			exitCode: exitEntropyTooLow,
+			wantCode: "E_ENTROPY_TOO_LOW",
+		},
+		{
+			name:     "charset empty after exclude",
+			args:     []string{"--json", "--charset", "digit-v1", "--exclude", "0123456789", "--min-entropy-bits", "0"},
+			exitCode: exitCharsetEmpty,
+			wantCode: "E_CHARSET_EMPTY",
+		},
+		{
+			name:     "class impossible",
+			args:     []string{"--json", "--charset", "digit-v1", "--require-classes", "symbol", "--min-entropy-bits", "0"},
+			exitCode: exitClassImpossible,
+			wantCode: "E_CLASS_IMPOSSIBLE",
+		},
+		{
+			name:     "schema version mismatch",
+			args:     []string{"--json", "--require-schema-version", "99"},
+			exitCode: exitInvalidArgs,
+			wantCode: "E_INVALID_ARGS",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stdout, stderr, code := runKeygen(t, tc.args...)
+			if code != tc.exitCode {
+				t.Errorf("exit=%d, want %d (stderr=%q)", code, tc.exitCode, stderr)
+			}
+			if stdout == "" {
+				t.Fatalf("expected JSON envelope on stdout, got empty (stderr=%q)", stderr)
+			}
+			out := decode(t, stdout)
+			if out.SchemaVersion != audit.SchemaVersion {
+				t.Errorf("schema_version = %d", out.SchemaVersion)
+			}
+			if out.Error == nil {
+				t.Fatalf("error field missing from envelope; got %+v", out)
+			}
+			if out.Error.Code != tc.wantCode {
+				t.Errorf("error.code = %q, want %q", out.Error.Code, tc.wantCode)
+			}
+			if out.Error.Message == "" {
+				t.Errorf("error.message empty")
+			}
+			if out.Error.Hint == "" {
+				t.Errorf("error.hint empty (expected curated remediation for known code)")
+			}
+			if out.Subcommand == "" {
+				t.Errorf("subcommand should be populated even on failure")
+			}
+			if out.Version == "" {
+				t.Errorf("version should be populated even on failure (build identity)")
+			}
+			mustValidUUID(t, out.RequestID)
+			// Plain mode (no --json): same args without --json should print
+			// to stderr instead — sanity check that we didn't break that path.
+			plainArgs := []string{}
+			for _, a := range tc.args {
+				if a != "--json" {
+					plainArgs = append(plainArgs, a)
+				}
+			}
+			_, plainStderr, plainCode := runKeygen(t, plainArgs...)
+			if plainCode != tc.exitCode {
+				t.Errorf("plain mode exit=%d, want %d", plainCode, tc.exitCode)
+			}
+			if plainStderr == "" {
+				t.Errorf("plain mode should still emit stderr on failure; got empty")
+			}
+		})
+	}
+}
+
 // --- helpers ---
 
 func decode(t *testing.T, s string) audit.Output {


### PR DESCRIPTION
Implements PR-8 (structured error output) and PR-11 (stable error code registry) from #13. Together they let agents handle CLI failures programmatically: branch on a stable string code, read a curated remediation hint, and never have to parse English prose.

## Summary

When `--json` is set and generation fails, the CLI now emits a schema-v1 envelope on stdout with a populated `error` object and stays silent on stderr. Agents see exactly one machine-readable artifact regardless of success or failure path:

```json
{
  "schema_version": 1,
  "subcommand": "password",
  "version": "v2.0.0",
  "commit": "abc1234",
  "build_date": "2026-05-02T22:00:00Z",
  "request_id": "8a7f...-...-...",
  "timestamp_utc": "2026-05-02T22:01:33Z",
  "error": {
    "code": "E_ENTROPY_TOO_LOW",
    "message": "policy: entropy below floor: 23.82 bits < floor 80.00",
    "hint": "increase --length, choose a richer --charset, or pass --allow-weak (records a warning)"
  }
}
```

Plain mode (without `--json`) keeps the legacy stderr+exit-code behavior unchanged.

## Stable error code registry (PR-11)

| code                  | exit | meaning                                                                                |
| --------------------- | ---: | -------------------------------------------------------------------------------------- |
| `E_INVALID_ARGS`      |    2 | Unknown flag, unknown charset, schema-version mismatch, malformed stdin, audit-log failure |
| `E_ENTROPY_TOO_LOW`   |    3 | Computed entropy below `--min-entropy-bits` and `--allow-weak` not set                 |
| `E_RNG_FAILURE`       |    4 | OS entropy source returned an error mid-generation                                     |
| `E_CHARSET_EMPTY`     |    5 | `--exclude` reduced charset below 2 runes                                              |
| `E_CLASS_IMPOSSIBLE`  |    6 | `--require-classes` cannot be satisfied                                                |

Each code has a curated one-line `hint` registered in `internal/audit/errors.go`. Agents branch on `code` (string), shell scripts on the integer `$?`.

## Architecture

- `internal/audit`: new `Error` struct, `NewError(code, message)` constructor, hint registry. Code constants exported (`audit.CodeInvalidArgs`, etc.).
- `internal/audit/schema.go`: `Output` gains an `*Error` field, `omitempty` so successful records are unchanged.
- `cmd/secretgenerator/exit.go`: `exitToCode(int) → string` mapping; `failJSON()` constructor that marks the error as already-emitted.
- `cmd/secretgenerator/runner.go`: new `errCtx{c, subcommand}` type with a `.fail(exitCode, err)` method that emits the structured envelope when `--json` is set, else falls through to legacy `fail()`.
- `cmd/secretgenerator/main.go`: respects `codedError.jsonEmitted` — does not duplicate to stderr when the subcommand already wrote JSON.
- All 6 subcommands updated: each `runX` constructs an `errCtx` once, all error paths go through `e.fail(...)` instead of global `fail(...)`.

## Schema delta

`schemas/output-v1.json` adds `error` as an optional object (additive, non-breaking — schema version stays at 1). Documented in `docs/SCHEMA.md` with the full code table, mapping to integer exit codes, and example.

## Tests

- 5 new E2E cases in `TestE2E_StructuredErrorsInJSON`, one per error code: invalid charset, entropy too low, charset empty, class impossible, schema-version mismatch. Each verifies:
  - stdout contains valid schema-v1 envelope
  - `error.code` matches the expected stable string
  - `error.hint` is non-empty (curated remediation)
  - `subcommand`, `version`, `request_id`, `timestamp_utc` are populated even on failure
  - plain mode (same args minus `--json`) still emits stderr — back-compat preserved
- 3 new unit tests in `internal/audit/errors_test.go` covering `NewError` (known/unknown codes) and `HintFor` registry coverage.

## Validation

- `go test ./... -count=1`: all 8 packages pass.
- `golangci-lint run ./...`: 0 issues.
- Manual smoke: `secretgenerator --json --length 4` returns valid JSON, exit 3, stderr empty.

## Closes

Part of [#13](#13) (PR-8 + PR-11).

## Branch hygiene

After merge: `git checkout main && git pull && git branch -d feat/structured-error-json && git push origin --delete feat/structured-error-json` per the repo cleanup convention.