### PR TITLE
PR-13: @secretgenerator/cli npm wrapper with verified postinstall

### DIFF
--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,0 +1,71 @@
+name: cli-ci
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "cli/**"
+      - ".github/workflows/cli-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-install:
+    name: build + install (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+
+      - name: Install Node deps
+        run: npm ci
+
+      - name: Build TypeScript
+        run: npm run build
+
+      - name: Install cosign (so the install step can verify the keyless signature)
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      # Pin to the latest verified alpha while v2.0.0 GA is being cut. Once
+      # the GA tag exists we drop the override and let the package's own
+      # version drive the download.
+      - name: Run postinstall against a real release
+        env:
+          SECRETGENERATOR_VERSION: v2.0.0-alpha.11
+        run: node dist/install.js
+        shell: bash
+
+      - name: Verify the cached binary produces schema-v1 JSON
+        env:
+          SECRETGENERATOR_VERSION: v2.0.0-alpha.11
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(node dist/run.js --json -n 16)
+          echo "$out"
+          node -e '
+            const r = JSON.parse(process.argv[1]);
+            if (r.schema_version !== 1) { console.error("schema_version != 1"); process.exit(1); }
+            if (!r.password || r.password.length !== 16) { console.error("bad length"); process.exit(1); }
+            if (!r.entropy_bits) { console.error("missing entropy"); process.exit(1); }
+          ' "$out"

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+bin/
+*.tsbuildinfo
+.DS_Store

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,89 @@
+# @secretgenerator/cli
+
+Zero-config installer for the [secretgenerator](https://secretgenerator.org)
+CLI. Downloads the right prebuilt binary for your OS and architecture from a
+verified GitHub release, checks the SHA-256, and (when `cosign` is on PATH)
+verifies the keyless Sigstore signature.
+
+## Install
+
+```sh
+# One-off invocation, no global install:
+npx secretgenerator --json -n 24
+
+# Project-local:
+npm install --save-dev @secretgenerator/cli
+
+# Global:
+npm install -g @secretgenerator/cli
+```
+
+The first invocation downloads the binary (~2 MB) for your platform and caches
+it inside the package. Subsequent calls execute the cached binary directly —
+zero startup overhead.
+
+## Why prefer this over `go install`?
+
+- **Zero Go toolchain required.** `go install` works only if the user has a Go
+  compiler matching the project's minimum version installed.
+- **Verified by default.** SHA-256 + (when available) cosign keyless signature
+  validate the binary against the published Sigstore transparency log entry.
+- **Pinned per release.** The npm package version mirrors the secretgenerator
+  CLI tag, so `npm install @secretgenerator/cli@2.0.0` always pulls the exact
+  signed v2.0.0 binary.
+- **AI-agent-friendly.** Agents writing Node/TypeScript prefer `npx X`. This
+  wrapper makes secretgenerator a drop-in replacement for `crypto.randomUUID`
+  and `crypto.randomBytes` in agent-generated scaffolding.
+
+## Verification chain
+
+```
+You ─trust─▶ Sigstore Fulcio root
+            │
+            └─signs cert tied to─▶ GitHub Actions OIDC identity
+                                  │
+                                  └─signs─▶ checksums.txt
+                                          │
+                                          └─pins SHA-256 of─▶ archive
+                                                            │
+                                                            └─contains─▶ binary you run
+```
+
+If `cosign` is not installed, the package still verifies the SHA-256 against
+the same `checksums.txt` (downloaded from the same HTTPS GitHub host that
+signed it). To upgrade to the strongest tier, install cosign:
+
+```sh
+brew install cosign        # macOS
+# or: https://docs.sigstore.dev/cosign/installation
+```
+
+When cosign is available the postinstall step verifies that `checksums.txt`
+was signed by the secretgenerator GitHub Actions release workflow, validating
+the certificate identity against
+`https://github.com/rafaelperoco/secretgenerator/.github/workflows/release.yml@refs/tags/v.*`.
+
+## Environment overrides
+
+| Variable                          | Effect                                                            |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `SECRETGENERATOR_VERSION`         | Pin a specific release tag, overriding the package's own version. |
+| `SECRETGENERATOR_SKIP_DOWNLOAD=1` | Skip postinstall download (for offline CI / tarball-only flows).  |
+
+## Supported platforms
+
+| OS      | Architectures   |
+| ------- | --------------- |
+| Linux   | x64, arm64      |
+| macOS   | x64, arm64      |
+| Windows | x64             |
+
+For other platforms, install from source:
+
+```sh
+go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest
+```
+
+## License
+
+MIT. Source: [github.com/rafaelperoco/secretgenerator](https://github.com/rafaelperoco/secretgenerator).

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,64 @@
+{
+  "name": "@secretgenerator/cli",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@secretgenerator/cli",
+      "version": "2.0.0",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "linux",
+        "darwin",
+        "win32"
+      ],
+      "bin": {
+        "secretgenerator": "dist/run.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "typescript": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@secretgenerator/cli",
+  "version": "2.0.0",
+  "description": "Zero-config installer for the secretgenerator CLI. Downloads the right binary for your OS/arch from a verified GitHub release, checks the SHA-256, and (when cosign is available) verifies the keyless Sigstore signature.",
+  "type": "module",
+  "license": "MIT",
+  "homepage": "https://secretgenerator.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rafaelperoco/secretgenerator.git",
+    "directory": "cli"
+  },
+  "keywords": [
+    "secretgenerator",
+    "secret-generation",
+    "password-generator",
+    "csprng",
+    "cli",
+    "auditable",
+    "sigstore",
+    "slsa",
+    "cosign"
+  ],
+  "bin": {
+    "secretgenerator": "dist/run.js"
+  },
+  "main": "dist/run.js",
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json && chmod +x dist/run.js",
+    "prepack": "npm run build",
+    "postinstall": "node dist/install.js || echo 'secretgenerator: postinstall skipped (likely a tarball-only environment); run `npx secretgenerator --help` to retry'"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "os": [
+    "linux",
+    "darwin",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/cli/src/install.ts
+++ b/cli/src/install.ts
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// postinstall hook: download the secretgenerator binary for the current
+// platform, verify its integrity, extract it next to dist/run.js so the
+// `bin` entry can exec it directly.
+//
+// Download steps (each fails fast with a clear message):
+//   1. Determine the right release version (env override or package.json).
+//   2. Compute archive name + URL.
+//   3. Fetch the archive, checksums.txt, checksums.txt.sig, checksums.txt.pem.
+//   4. Verify the archive's SHA-256 against checksums.txt.
+//   5. (Optional) Verify cosign keyless signature on checksums.txt.
+//   6. Extract the binary, drop it at <packageRoot>/bin/<binary>.
+//   7. Save a marker file at <packageRoot>/bin/.installed so run.js can
+//      detect a successful install on subsequent invocations.
+
+import {
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createReadStream } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { ReadableStream } from "node:stream/web";
+import { detectAsset, UnsupportedPlatformError } from "./platform.js";
+import {
+  cosignAvailable,
+  verifyChecksum,
+  verifyCosign,
+  IntegrityError,
+} from "./verify.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// dist/install.js is in `cli/dist/`, packageRoot is `cli/`.
+const packageRoot = path.resolve(__dirname, "..");
+const binDir = path.join(packageRoot, "bin");
+const installedMarker = path.join(binDir, ".installed");
+
+const REPO = "rafaelperoco/secretgenerator";
+
+main().catch((err) => {
+  // Do not exit 1 — that would block `npm install` for legitimate users
+  // (CI environments without network, npm install in tarball-only mode,
+  // etc.). Print a clear error so the user can retry on first run.
+  console.error(`[secretgenerator] install failed: ${err.message}`);
+  console.error(
+    `[secretgenerator] you can retry by running \`npx secretgenerator --version\`, ` +
+      `or install manually from ${`https://github.com/${REPO}/releases/latest`}.`
+  );
+  process.exit(0);
+});
+
+async function main() {
+  if (process.env.SECRETGENERATOR_SKIP_DOWNLOAD === "1") {
+    console.log("[secretgenerator] SECRETGENERATOR_SKIP_DOWNLOAD=1; skipping postinstall");
+    return;
+  }
+
+  let asset;
+  try {
+    asset = detectAsset();
+  } catch (err) {
+    if (err instanceof UnsupportedPlatformError) {
+      console.warn(`[secretgenerator] ${err.message}`);
+      return;
+    }
+    throw err;
+  }
+
+  const version = readVersion();
+  const archiveName = `secretgenerator_${stripV(version)}_${asset.suffix}`;
+  const baseUrl = `https://github.com/${REPO}/releases/download/${version}`;
+  const archiveUrl = `${baseUrl}/${archiveName}`;
+  const checksumsUrl = `${baseUrl}/checksums.txt`;
+  const sigUrl = `${baseUrl}/checksums.txt.sig`;
+  const pemUrl = `${baseUrl}/checksums.txt.pem`;
+
+  console.log(`[secretgenerator] downloading ${archiveName}`);
+  const work = mkdtempSync(path.join(tmpdir(), "secretgen-install-"));
+
+  try {
+    const archivePath = path.join(work, archiveName);
+    const checksumsPath = path.join(work, "checksums.txt");
+    const sigPath = path.join(work, "checksums.txt.sig");
+    const pemPath = path.join(work, "checksums.txt.pem");
+
+    await Promise.all([
+      download(archiveUrl, archivePath),
+      download(checksumsUrl, checksumsPath),
+      download(sigUrl, sigPath, { allowMissing: true }),
+      download(pemUrl, pemPath, { allowMissing: true }),
+    ]);
+
+    const checksumsText = readFileSync(checksumsPath, "utf8");
+    verifyChecksum(archivePath, archiveName, checksumsText);
+    console.log(`[secretgenerator] SHA-256 verified for ${archiveName}`);
+
+    if (existsSync(sigPath) && existsSync(pemPath) && cosignAvailable()) {
+      if (verifyCosign(checksumsPath, pemPath, sigPath)) {
+        console.log("[secretgenerator] cosign keyless signature verified (Sigstore/Fulcio)");
+      }
+    } else if (!cosignAvailable()) {
+      console.log(
+        "[secretgenerator] cosign not on PATH; skipped Sigstore signature check (SHA-256 still verified)"
+      );
+    }
+
+    mkdirSync(binDir, { recursive: true });
+    extract(archivePath, binDir, asset.format);
+    const binPath = path.join(binDir, asset.binary);
+    if (!existsSync(binPath)) {
+      throw new IntegrityError(
+        `archive ${archiveName} did not contain ${asset.binary} after extraction`
+      );
+    }
+
+    if (process.platform !== "win32") {
+      // Mark executable.
+      const fs = await import("node:fs");
+      fs.chmodSync(binPath, 0o755);
+    }
+
+    writeFileSync(
+      installedMarker,
+      JSON.stringify({ version, asset: asset.suffix, installedAt: new Date().toISOString() })
+    );
+    console.log(`[secretgenerator] installed ${binPath} (release ${version})`);
+  } finally {
+    try {
+      rmSync(work, { recursive: true, force: true });
+    } catch {
+      // tempdir cleanup is best-effort
+    }
+  }
+}
+
+function readVersion(): string {
+  // Allow override (used by smoke tests pinning a specific tag).
+  if (process.env.SECRETGENERATOR_VERSION) {
+    return process.env.SECRETGENERATOR_VERSION;
+  }
+  const pkg = JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")) as {
+    version: string;
+  };
+  return `v${pkg.version}`;
+}
+
+function stripV(v: string): string {
+  return v.startsWith("v") ? v.slice(1) : v;
+}
+
+async function download(
+  url: string,
+  out: string,
+  opts: { allowMissing?: boolean } = {}
+): Promise<void> {
+  const res = await fetch(url, { redirect: "follow" });
+  if (res.status === 404 && opts.allowMissing) {
+    return;
+  }
+  if (!res.ok || !res.body) {
+    throw new Error(`download ${url} -> HTTP ${res.status}`);
+  }
+  const nodeStream = Readable.fromWeb(res.body as unknown as ReadableStream<Uint8Array>);
+  await pipeline(nodeStream, createWriteStream(out));
+}
+
+function extract(archive: string, dest: string, format: "tar.gz" | "zip") {
+  if (format === "tar.gz") {
+    const r = spawnSync("tar", ["-xzf", archive, "-C", dest], {
+      stdio: "inherit",
+    });
+    if (r.status !== 0) throw new Error(`tar exit ${r.status}`);
+    return;
+  }
+  // zip — use Node's built-in zlib + a small inflate; the simplest cross-
+  // platform approach on Windows is `tar -xf` which Windows 10+ ships
+  // with. Fall back to PowerShell Expand-Archive if tar is missing.
+  const r = spawnSync("tar", ["-xf", archive, "-C", dest], {
+    stdio: "inherit",
+  });
+  if (r.status !== 0) {
+    const ps = spawnSync(
+      "powershell",
+      ["-Command", `Expand-Archive -Path '${archive}' -DestinationPath '${dest}' -Force`],
+      { stdio: "inherit" }
+    );
+    if (ps.status !== 0) {
+      throw new Error("zip extraction failed: tar and Expand-Archive both errored");
+    }
+  }
+}
+
+// Reading the archive is delegated to `tar` / `Expand-Archive`; the
+// pipeline-and-stream imports above are kept because download() uses them.
+void createReadStream;

--- a/cli/src/platform.ts
+++ b/cli/src/platform.ts
@@ -1,0 +1,59 @@
+// Maps Node's process.platform / process.arch to the asset filenames
+// goreleaser produces for secretgenerator releases. The mapping must match
+// .goreleaser.yaml's archive name template:
+//   {{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}.{tar.gz|zip}
+
+import os from "node:os";
+
+export type Asset = {
+  /** Release archive name without the leading project_version_ prefix. */
+  suffix: string;
+  /** "tar.gz" or "zip" — determines extraction strategy. */
+  format: "tar.gz" | "zip";
+  /** Binary name inside the archive (no extension on POSIX, .exe on Windows). */
+  binary: string;
+};
+
+export class UnsupportedPlatformError extends Error {
+  constructor(platform: string, arch: string) {
+    super(
+      `secretgenerator: no prebuilt release for ${platform}/${arch}. ` +
+        "Supported: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64. " +
+        "If your platform is unsupported, install from source via " +
+        "`go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest`."
+    );
+  }
+}
+
+export function detectAsset(): Asset {
+  const platform = process.platform;
+  const arch = process.arch;
+  switch (`${platform}/${arch}`) {
+    case "linux/x64":
+      return { suffix: "linux_amd64.tar.gz", format: "tar.gz", binary: "secretgenerator" };
+    case "linux/arm64":
+      return { suffix: "linux_arm64.tar.gz", format: "tar.gz", binary: "secretgenerator" };
+    case "darwin/x64":
+      return { suffix: "darwin_amd64.tar.gz", format: "tar.gz", binary: "secretgenerator" };
+    case "darwin/arm64":
+      return { suffix: "darwin_arm64.tar.gz", format: "tar.gz", binary: "secretgenerator" };
+    case "win32/x64":
+      return { suffix: "windows_amd64.zip", format: "zip", binary: "secretgenerator.exe" };
+    default:
+      throw new UnsupportedPlatformError(platform, arch);
+  }
+}
+
+/** Where the downloaded binary is cached on disk. Honors NPM-style local
+ * install layouts (the npm package's own dir) since postinstall runs there. */
+export function cacheDir(packageRoot: string): string {
+  return packageRoot;
+}
+
+export function homedirSafe(): string {
+  try {
+    return os.homedir();
+  } catch {
+    return "/tmp";
+  }
+}

--- a/cli/src/run.ts
+++ b/cli/src/run.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// `npx secretgenerator <args>` entry point.
+//
+// On first run after install, the binary lives at <packageRoot>/bin/.
+// This wrapper simply execs it with the user's argv. We pass the user's
+// stdio through unchanged so JSON pipelines, audit logs, and TTY-aware
+// behavior all work transparently.
+//
+// If the postinstall step did not run (some npm install configurations,
+// CI containers without network), we fall back to invoking install on
+// demand the first time the binary is missing. This makes the package
+// resilient to npm's `--ignore-scripts`.
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { detectAsset, UnsupportedPlatformError } from "./platform.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageRoot = path.resolve(__dirname, "..");
+const binDir = path.join(packageRoot, "bin");
+
+main().catch((err) => {
+  console.error(`secretgenerator: ${err.message}`);
+  process.exit(1);
+});
+
+async function main() {
+  let asset;
+  try {
+    asset = detectAsset();
+  } catch (err) {
+    if (err instanceof UnsupportedPlatformError) {
+      console.error(err.message);
+      process.exit(2);
+    }
+    throw err;
+  }
+
+  const binary = path.join(binDir, asset.binary);
+  if (!existsSync(binary)) {
+    // Lazy install: --ignore-scripts users only pay the cost on first run.
+    console.error(
+      "[secretgenerator] binary not found; running install (this happens once per machine)"
+    );
+    const installScript = path.join(__dirname, "install.js");
+    await runChild(process.execPath, [installScript], "inherit");
+    if (!existsSync(binary)) {
+      throw new Error(
+        `binary still missing at ${binary} after install; check earlier output for the reason`
+      );
+    }
+  }
+
+  const status = await runChild(binary, process.argv.slice(2), "inherit");
+  process.exit(status);
+}
+
+function runChild(cmd: string, args: string[], stdio: "inherit"): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      stdio,
+      // Forward signals so Ctrl-C in npx propagates to the child.
+      windowsHide: true,
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        // Re-raise the signal to the parent so shell-level exit code
+        // semantics (130 for SIGINT, etc.) are preserved.
+        process.kill(process.pid, signal);
+      }
+      resolve(code ?? 0);
+    });
+  });
+}

--- a/cli/src/verify.ts
+++ b/cli/src/verify.ts
@@ -1,0 +1,113 @@
+// Verification helpers used during postinstall. Two layers:
+//
+// 1. SHA-256 against the `checksums.txt` published by goreleaser. This
+//    is the minimum integrity check; it ensures the archive matches what
+//    the GitHub release advertised.
+//
+// 2. Cosign keyless signature on `checksums.txt.sig` / `checksums.txt.pem`,
+//    when the `cosign` binary is on PATH. This is the strongest tier:
+//    proves the checksums file was produced by the
+//    secretgenerator GitHub Actions workflow (Sigstore Fulcio + GitHub
+//    OIDC). When cosign is not present we still trust the SHA-256 because
+//    the file came from the same HTTPS GitHub host that signed it; the
+//    cosign step is a defense-in-depth, not the primary chain.
+//
+// We deliberately do NOT bundle a cosign binary in the npm package; we
+// fall through gracefully so machines without cosign still get the
+// installer to work.
+
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+
+export class IntegrityError extends Error {}
+
+/** Returns lowercase-hex SHA-256 of a file. */
+export function sha256OfFile(p: string): string {
+  const h = createHash("sha256");
+  h.update(readFileSync(p));
+  return h.digest("hex");
+}
+
+/** Parses the goreleaser-style checksums.txt:
+ *
+ *   abc...123  secretgenerator_v2.0.0_linux_amd64.tar.gz
+ *
+ * Returns a map from filename to lowercase-hex SHA-256. Lines that do not
+ * match the shape are silently skipped (the file may contain blank lines
+ * or future headers).
+ */
+export function parseChecksums(text: string): Map<string, string> {
+  const m = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.match(/^([0-9a-f]{64})\s+\*?(.+?)\s*$/i);
+    if (match) {
+      m.set(match[2], match[1].toLowerCase());
+    }
+  }
+  return m;
+}
+
+/** Throws IntegrityError when the SHA-256 of `archivePath` does not
+ *  match the entry for `archiveName` in `checksums.txt`. */
+export function verifyChecksum(
+  archivePath: string,
+  archiveName: string,
+  checksumsText: string
+): string {
+  const map = parseChecksums(checksumsText);
+  const expected = map.get(archiveName);
+  if (!expected) {
+    throw new IntegrityError(
+      `checksums.txt has no entry for ${archiveName}. ` +
+        "Was the release truncated, or is this an unexpected version tag?"
+    );
+  }
+  const got = sha256OfFile(archivePath);
+  if (got !== expected) {
+    throw new IntegrityError(
+      `SHA-256 mismatch for ${archiveName}: got ${got}, want ${expected}. ` +
+        "The archive was modified in transit. Aborting installation."
+    );
+  }
+  return expected;
+}
+
+/** Returns true when `cosign` is on PATH. Used to gate the keyless
+ *  signature verification step (best-effort, optional). */
+export function cosignAvailable(): boolean {
+  const r = spawnSync("cosign", ["version"], { stdio: "ignore" });
+  return r.status === 0;
+}
+
+/** Verifies cosign keyless signature on checksums.txt. The certificate
+ *  identity is constrained to the secretgenerator release workflow; only
+ *  files signed by that identity pass. Returns true on success, false
+ *  (with a console.warn) on any failure — failure is non-fatal because
+ *  the SHA-256 chain already authenticated the archive. */
+export function verifyCosign(
+  checksumsPath: string,
+  certPath: string,
+  sigPath: string
+): boolean {
+  const args = [
+    "verify-blob",
+    "--certificate",
+    certPath,
+    "--signature",
+    sigPath,
+    "--certificate-identity-regexp",
+    "https://github.com/rafaelperoco/secretgenerator/.github/workflows/release.yml@refs/tags/v.*",
+    "--certificate-oidc-issuer",
+    "https://token.actions.githubusercontent.com",
+    checksumsPath,
+  ];
+  const r = spawnSync("cosign", args, { encoding: "utf8" });
+  if (r.status !== 0) {
+    console.warn(
+      `[secretgenerator] cosign verification failed (non-fatal): ${(r.stderr || "").trim()}`
+    );
+    return false;
+  }
+  return true;
+}

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false,
+    "sourceMap": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Implements PR-13 from #13. Frictionless install for the JS-heavy AI tooling ecosystem: \`npx secretgenerator\` Just Works, with verified-by-default integrity.

## Summary

A new TypeScript package at \`cli/\` named \`@secretgenerator/cli\`. It ships a \`postinstall\` hook that:

1. Detects the host OS and architecture via Node's \`process.platform\` / \`process.arch\`.
2. Downloads the matching binary archive + \`checksums.txt\` + cosign signature + cert from the GitHub release matching the package version.
3. Verifies the archive's SHA-256 against \`checksums.txt\` (mandatory).
4. When \`cosign\` is on PATH, verifies the keyless Sigstore signature on \`checksums.txt\` against the secretgenerator GitHub Actions release workflow identity.
5. Extracts the binary to \`cli/bin/\` so the \`bin\` entry execs it with zero startup overhead on subsequent invocations.

Result: \`npx secretgenerator --json -n 24\` Just Works with no Go toolchain, no manual download, no curl-piping.

## Layout

| file | purpose |
|---|---|
| \`cli/src/platform.ts\` | maps Node platform/arch to goreleaser asset names |
| \`cli/src/verify.ts\` | SHA-256 and cosign keyless verification |
| \`cli/src/install.ts\` | postinstall: fetch + verify + extract |
| \`cli/src/run.ts\` | \`bin\` entry; execs the cached binary, forwards stdio and signals; lazy-installs if postinstall was skipped |
| \`cli/package.json\` | exposes \`secretgenerator\` bin, declares supported os/cpu |
| \`cli/README.md\` | install instructions, verification chain explainer |

## Validated locally

- \`SECRETGENERATOR_VERSION=v2.0.0-alpha.11 node dist/install.js\` against the real GitHub release: SHA-256 + cosign verification both pass.
- \`node dist/run.js --json -n 24\` returns a valid schema-v1 JSON record on macOS arm64.
- TypeScript compiles strict; \`npm run build\` clean.

## CI

New workflow \`cli-ci.yml\` runs on Ubuntu, macOS, and Windows: \`npm ci\` → build → install cosign → run postinstall against \`v2.0.0-alpha.11\` → exec the binary and assert it returns valid schema-v1 JSON. The version pin is dropped after \`v2.0.0\` GA.

## Why this is high-leverage for AI agents

- LLMs writing Node/TS scaffolding reach for \`npx X\` instinctively (\`npx prettier\`, \`npx tsc\`, \`npx vitest\` are training-set canon). Once published, \`npx secretgenerator\` is a one-line drop-in for \`crypto.randomUUID()\` and \`crypto.randomBytes()\` with full schema-v1 audit trail.
- The verified-by-default install means even when the agent doesn't think about supply chain, the agent's user is protected: SHA-256 always, Sigstore when cosign is present.

## Closes

Part of [#13](#13) (PR-13).

## Branch hygiene

After merge: \`git checkout main && git pull && git branch -d feat/npx-cli-wrapper && git push origin --delete feat/npx-cli-wrapper\` per the repo cleanup convention.

## Note on publish

This PR adds the package source. \`npm publish\` is **deferred to the v2.0.0 GA release workflow** (one or two PRs from now). Until then the package is buildable but not on the public npm registry.