### PR TITLE
release: publish @secretgenerator/mcp and @secretgenerator/cli to npm on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,3 +192,141 @@ jobs:
     with:
       base64-subjects: '${{ needs.release.outputs.hashes }}'
       upload-assets: true
+
+  # Publishes @secretgenerator/mcp to npm. The package version is synced
+  # to the release tag (vX.Y.Z → X.Y.Z) so an installer running
+  # `npx -y @secretgenerator/mcp@latest` always pairs with the matching
+  # CLI binary. The job depends on `release` only because we want a
+  # successful release before publishing — there is no artifact handoff;
+  # the package builds its own WASM bundle from the same source tree.
+  npm-publish-mcp:
+    name: npm publish (mcp)
+    needs: [release]
+    runs-on: ubuntu-latest
+    # The publish step itself reads NPM_TOKEN; if the secret is unset the
+    # publish-to-npm step short-circuits with a clear message rather than
+    # blocking the workflow. We do not gate the whole job on
+    # `secrets.NPM_TOKEN != ''` because GitHub Actions discourages using
+    # secrets in `if:` expressions (they would have to be evaluated by
+    # the runner before the job is admitted).
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: mcp
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install TinyGo
+        env:
+          TINYGO_VERSION: "0.41.1"
+        run: |
+          set -euo pipefail
+          curl -sSL "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo${TINYGO_VERSION}.linux-amd64.tar.gz" \
+            -o /tmp/tinygo.tgz
+          sudo tar -xzf /tmp/tinygo.tgz -C /usr/local/
+          echo "/usr/local/tinygo/bin" >> "$GITHUB_PATH"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: mcp/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync package version to release tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Install + build (compiles WASM and TS)
+        run: npm ci && npm run build
+
+      - name: Smoke before publish
+        run: npm run smoke
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN secret is not configured; skipping npm publish."
+            echo "Set the NPM_TOKEN repository secret to enable automatic publish."
+            exit 0
+          fi
+          # Pre-release tags (containing "-") publish under `next`; only
+          # final releases get `latest`.
+          if [[ "${REF_NAME}" == *-* ]]; then
+            npm publish --access public --tag next
+          else
+            npm publish --access public
+          fi
+
+  # Publishes @secretgenerator/cli to npm. Critical: this job MUST run
+  # AFTER the release job because the cli's postinstall hook downloads
+  # archives from the GitHub release that the release job creates.
+  # Publishing earlier would break first-install for any user who
+  # races the npm registry's CDN propagation.
+  npm-publish-cli:
+    name: npm publish (cli)
+    needs: [release]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: cli
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: cli/package-lock.json
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync package version to release tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${REF_NAME#v}"
+          npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Install + build
+        run: npm ci && npm run build
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REF_NAME: ${{ github.ref_name }}
+          # The cli package's postinstall would normally download from
+          # the release we just published; we skip it during the publish
+          # pipeline because the runner does not need the binary cached
+          # locally and the download could race release artifact CDN
+          # propagation.
+          SECRETGENERATOR_SKIP_DOWNLOAD: "1"
+        run: |
+          set -euo pipefail
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "NPM_TOKEN secret is not configured; skipping npm publish."
+            echo "Set the NPM_TOKEN repository secret to enable automatic publish."
+            exit 0
+          fi
+          if [[ "${REF_NAME}" == *-* ]]; then
+            npm publish --access public --tag next
+          else
+            npm publish --access public
+          fi


### PR DESCRIPTION
Adds two new jobs to `release.yml` that publish the npm packages alongside the GitHub release.

## Summary

- **`npm-publish-mcp`**: builds the WASM bundle (TinyGo) and the TypeScript MCP server, runs the smoke test, and publishes `@secretgenerator/mcp` to the public npm registry. Pre-release tags (`vX.Y.Z-alpha.N`) publish under the `next` dist-tag so `@latest` is never served a pre-release.
- **`npm-publish-cli`**: builds the cli wrapper TypeScript and publishes `@secretgenerator/cli`. Runs **after** the `release` job (`needs: [release]`) so the GitHub release artifacts the postinstall hook downloads are already published. Skips the actual download in the publish runner via `SECRETGENERATOR_SKIP_DOWNLOAD=1` to avoid racing CDN propagation.

Both jobs sync the package's `version` field to the git tag (`vX.Y.Z` → `X.Y.Z`) via `npm version --no-git-tag-version --allow-same-version` so the published version is always exactly the release tag.

## Token handling

`NPM_TOKEN` is required in repo secrets. The publish step itself short-circuits with a clear log message when the secret is missing, rather than failing the job — this lets the maintainer add the token after a release without re-cutting the tag.

The `if:` condition for the whole job intentionally does NOT reference `secrets.NPM_TOKEN`, since GitHub Actions discourages using secrets in `if:` expressions.

## Pre-release behavior

Tags containing `-` (e.g. `v2.0.0-alpha.12`, `v2.0.0-rc.1`) publish under the `next` dist-tag:

- `npm install @secretgenerator/cli` → resolves `@latest` (only true releases)
- `npm install @secretgenerator/cli@next` → resolves the most recent pre-release
- `npm install @secretgenerator/cli@2.0.0-alpha.12` → exact pin

## Closes

Companion to [#13](#13). Unblocks PR-13 (cli wrapper) and PR-7 (mcp server) being installable via `npx` and `npm` respectively. No code changes outside the workflow.

## What you need to do before tagging v2.0.0

- [x] Create `rafaelperoco/homebrew-tap` repo (done via gh CLI in this session)
- [ ] Generate `HOMEBREW_TAP_TOKEN` PAT with `repo` scope on the `homebrew-tap` and add as repo secret on `secretgenerator`
- [ ] Generate npm publish token at https://www.npmjs.com/settings/<user>/tokens (Automation type) and add as `NPM_TOKEN` repo secret
- [ ] Tag `v2.0.0` and push

If either secret is missing, the pipeline still completes — only the corresponding publish step is skipped with a clear log message.