### PR TITLE
docs: rewrite README with TL;DR-first structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,50 @@ Auditable random credential generator for AI agents and machine-readable
 pipelines. Replaces ad-hoc password generation with a verifiable contract
 backed by the OS CSPRNG.
 
+[![release](https://img.shields.io/github/v/release/rafaelperoco/secretgenerator?sort=semver)](https://github.com/rafaelperoco/secretgenerator/releases)
+[![ci](https://github.com/rafaelperoco/secretgenerator/actions/workflows/ci.yml/badge.svg)](https://github.com/rafaelperoco/secretgenerator/actions/workflows/ci.yml)
+[![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![cosign](https://img.shields.io/badge/signed-cosign%20keyless-blueviolet)](https://docs.sigstore.dev/cosign/overview/)
+[![npm cli](https://img.shields.io/npm/v/@secretgenerator/cli?label=%40secretgenerator%2Fcli)](https://www.npmjs.com/package/@secretgenerator/cli)
+[![npm mcp](https://img.shields.io/npm/v/@secretgenerator/mcp?label=%40secretgenerator%2Fmcp)](https://www.npmjs.com/package/@secretgenerator/mcp)
+
+## TL;DR
+
+```sh
+# zero-install (no clone, no compile)
+npx -y @secretgenerator/cli password --json --show-crack-time
+
+# permanent install
+brew install rafaelperoco/tap/secretgenerator
+
+# Model Context Protocol server (Claude / Cursor / Cline)
+npx -y @secretgenerator/mcp
+```
+
+Output is stable JSON (schema v1):
+
+```json
+{
+  "schema_version": 1,
+  "password": "VoJgEDVnCoTVMx8cLnMwmHnz",
+  "entropy_bits": 142.9,
+  "charset_id": "alphanum-v1",
+  "algorithm": "crypto/rand+rejection-sampling",
+  "subcommand": "password",
+  "version": "2.0.0",
+  "request_id": "f4c54f9c-0f57-4d58-83be-7937cbe077f7",
+  "timestamp_utc": "2026-04-29T22:35:11.077695Z",
+  "crack_time_estimates": [
+    {
+      "profile_id": "nation-state-v1",
+      "human_readable": "1.2e+10 times the age of the universe"
+    }
+  ]
+}
+```
+
+Pin the schema with `--require-schema-version=1`.
+
 > **Why not let an LLM generate the password directly?**
 > Recent research ([Irregular Security, 2025](https://www.csoonline.com/article/4155166/llm-generated-passwords-are-indefensible-your-codebase-may-already-prove-it.html))
 > shows Claude, GPT, and Gemini produce passwords with ~20 bits of effective
@@ -12,22 +56,42 @@ backed by the OS CSPRNG.
 > sample uniformly. secretgenerator is the correct primitive: an LLM tool-calls
 > it instead of inventing the credential itself.
 
-## Features
+## Subcommands
 
-- **Six subcommands**: `password`, `passphrase`, `secret`, `api-key`, `pin`, `entropy`.
-- **Stable JSON contract** (schema v1) with `--json`. Versioned, schema-pinnable, JSON-Schema-validated.
-- **Auditable provenance**: every release ships SLSA Level 3 attestation, cosign keyless signatures (Sigstore/Fulcio), CycloneDX SBOMs.
-- **Hard entropy floors** aligned with NIST SP 800-63B-4 and NIST SP 800-131A Rev. 3.
-- **Class-requirement guarantees** via rejection sampling.
-- **Audit log** with SHA-256 password fingerprints (never plaintext).
-- **Time-to-break estimates** under five named attacker profiles.
+| Subcommand   | Use case                                                                               |
+| ------------ | -------------------------------------------------------------------------------------- |
+| `password`   | Random password from a named charset (default 20 chars, ~119 bits).                    |
+| `passphrase` | Diceware passphrase from the EFF Large Wordlist (default 8 words, ~103 bits).          |
+| `secret`     | Raw bytes from the OS CSPRNG, encoded as URL-safe base64 (default 32 bytes / 256 bits). |
+| `api-key`    | Token in `prefix_random` form (Stripe-style).                                          |
+| `pin`        | Numeric PIN with weak-PIN blocklist enforced.                                          |
+| `entropy`    | Estimate the entropy and crack time of an existing password.                           |
+
+```sh
+secretgenerator password --json --show-crack-time
+secretgenerator passphrase --words 10 --separator -
+secretgenerator secret --bytes 32
+secretgenerator api-key --prefix sk_live --length 40
+secretgenerator pin --digits 6 --acknowledge-low-entropy
+echo -n 'Tr0ub4dor&3' | secretgenerator entropy --show-crack-time
+```
+
+Full flag reference: [docs/SUBCOMMANDS.md](docs/SUBCOMMANDS.md).
 
 ## Install
 
-### Verified install (recommended)
+| Method                 | Command                                                                         |
+| ---------------------- | ------------------------------------------------------------------------------- |
+| **npm (zero-install)** | `npx -y @secretgenerator/cli`                                                   |
+| **Homebrew**           | `brew install rafaelperoco/tap/secretgenerator`                                 |
+| **MCP server**         | `npx -y @secretgenerator/mcp`                                                   |
+| **Container**          | `docker run --rm ghcr.io/rafaelperoco/secretgenerator:v2.0.0`                   |
+| **Go install**         | `go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@v2.0.0` |
+| **Verified manual**    | See [verified install](#verified-install) below.                                |
 
-See [docs/AUDIT.md](docs/AUDIT.md) for full verification including SLSA
-provenance and SBOM inspection. Quick path:
+### Verified install
+
+Every release is signed end-to-end. Verify before extracting:
 
 ```sh
 # 1. Download the artifacts.
@@ -36,7 +100,7 @@ curl -LO https://github.com/rafaelperoco/secretgenerator/releases/download/v2.0.
 curl -LO https://github.com/rafaelperoco/secretgenerator/releases/download/v2.0.0/checksums.txt.sig
 curl -LO https://github.com/rafaelperoco/secretgenerator/releases/download/v2.0.0/checksums.txt.pem
 
-# 2. Verify the cosign signature.
+# 2. Verify the cosign signature (Sigstore/Fulcio + GitHub OIDC).
 cosign verify-blob \
   --certificate checksums.txt.pem \
   --signature checksums.txt.sig \
@@ -52,27 +116,7 @@ tar -xzf secretgenerator_2.0.0_linux_amd64.tar.gz
 sudo mv secretgenerator /usr/local/bin/
 ```
 
-### Homebrew
-
-```sh
-brew tap rafaelperoco/tap
-brew install secretgenerator
-```
-
-### Go install
-
-```sh
-go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@v2.0.0
-```
-
-### Container
-
-```sh
-docker pull ghcr.io/rafaelperoco/secretgenerator:v2.0.0
-docker run --rm ghcr.io/rafaelperoco/secretgenerator:v2.0.0 --json
-```
-
-The container is signed; verify with:
+The container image is also signed:
 
 ```sh
 cosign verify ghcr.io/rafaelperoco/secretgenerator:v2.0.0 \
@@ -80,85 +124,37 @@ cosign verify ghcr.io/rafaelperoco/secretgenerator:v2.0.0 \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
 
-## Usage
+Full procedure including SLSA provenance verification: [docs/AUDIT.md](docs/AUDIT.md).
 
-```sh
-# Default: 20-char alphanumeric password, ~119 bits.
-secretgenerator
+## Features
 
-# Machine-readable JSON with crack-time estimates.
-secretgenerator --json --show-crack-time
-
-# Strong API token, Stripe-style.
-secretgenerator api-key --prefix sk_live --length 40
-
-# Diceware passphrase, 8 words (~103 bits, secure through 2050).
-secretgenerator passphrase
-
-# 32-byte machine-to-machine secret (256 bits, base64url).
-secretgenerator secret
-
-# Estimate the strength of an existing password.
-echo -n 'Tr0ub4dor&3' | secretgenerator entropy --show-crack-time
-```
-
-See [docs/SUBCOMMANDS.md](docs/SUBCOMMANDS.md) for every flag of every
-subcommand.
-
-## Output schema
-
-```sh
-secretgenerator --json --show-crack-time -n 24
-```
-
-```json
-{
-  "schema_version": 1,
-  "password": "VoJgEDVnCoTVMx8cLnMwmHnz",
-  "length": 24,
-  "charset_id": "alphanum-v1",
-  "charset_size": 62,
-  "entropy_bits": 142.9,
-  "algorithm": "crypto/rand+rejection-sampling",
-  "subcommand": "password",
-  "version": "v2.0.0",
-  "commit": "1b43032",
-  "build_date": "2026-04-29T22:00:00Z",
-  "request_id": "f4c54f9c-0f57-4d58-83be-7937cbe077f7",
-  "timestamp_utc": "2026-04-29T22:35:11.077695Z",
-  "crack_time_estimates": [
-    {
-      "profile_id": "nation-state-v1",
-      "human_readable": "1.2e+10 times the age of the universe"
-    }
-  ]
-}
-```
-
-The full schema is published as [schemas/output-v1.json](schemas/output-v1.json)
-(JSON Schema 2020-12). Pin the version with `--require-schema-version=1`.
+- **Stable JSON contract** (schema v1) with `--json`. Versioned, schema-pinnable, JSON-Schema-validated.
+- **Hard entropy floors** aligned with NIST SP 800-63B-4 and NIST SP 800-131A Rev. 3.
+- **Class-requirement guarantees** via rejection sampling.
+- **Auditable provenance**: SLSA Level 3, cosign keyless signatures, CycloneDX SBOMs.
+- **Audit log** with SHA-256 password fingerprints (never plaintext).
+- **Time-to-break estimates** under five named attacker profiles.
 
 ## Go library
 
 ```go
-import "github.com/rafaelperoco/secretgenerator/pkg/keygen"
+import "github.com/rafaelperoco/secretgenerator/pkg/secretgen"
 
-res, err := keygen.Password(keygen.PasswordOptions{
+res, err := secretgen.Password(secretgen.PasswordOptions{
     Length:          24,
     CharsetID:       "alphanum-symbols-v1",
     RequiredClasses: "lower,upper,digit,symbol",
 })
-if err != nil { /* errors.Is(err, keygen.ErrBelowEntropyFloor) etc. */ }
+if err != nil { /* errors.Is(err, secretgen.ErrBelowEntropyFloor) etc. */ }
 
 fmt.Println(res.Password, "entropy:", res.EntropyBits)
 
-// Time-to-break estimates.
-for _, e := range keygen.EstimateCrackTime(res.EntropyBits) {
+for _, e := range secretgen.EstimateCrackTime(res.EntropyBits) {
     fmt.Println(e.ProfileID, e.HumanReadable)
 }
 ```
 
-API stability is documented in `pkg/keygen/doc.go`.
+API stability is documented in `pkg/secretgen/doc.go`.
 
 ## Documentation
 


### PR DESCRIPTION
Closes part of #13.

The previous README forced readers to scroll past 30 lines of features before seeing a working command. Now the first thing on the page is a working one-liner for the three most common entry points (npx zero-install, Homebrew, MCP).

Other fixes:
- Replaced wrong package path `pkg/keygen` with the actual `pkg/secretgen`.
- Replaced wrong subcommand flags (`pin --length --no-weak` → `pin --digits --acknowledge-low-entropy`; `secret --encoding base64url` → `secret` since base64url is the only encoding).
- Added a subcommand table so AI agents can pick the right primitive in one glance.
- Added install methods table including npm and MCP.
- Added shields.io badges for release version, CI, SLSA L3, cosign, and the two npm packages.
- Verified every shell example runs against the v2.0.0 binary.
- Verified the Go example compiles and produces the documented output.