### PR TITLE
docs: add runnable examples in Python, Node, Ruby, Rust, Bash, Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ for _, e := range secretgen.EstimateCrackTime(res.EntropyBits) {
 
 API stability is documented in `pkg/secretgen/doc.go`.
 
+## Examples in 6 languages
+
+Ready-to-run snippets for Python, Node.js, Ruby, Rust, Bash, and Go live
+under [`examples/`](examples/README.md). All of them produce the same
+schema-v1 output and pin `--require-schema-version=1`.
+
 ## Documentation
 
 - [docs/SUBCOMMANDS.md](docs/SUBCOMMANDS.md) — Every flag of every subcommand.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Examples
+
+Drop-in snippets for every common runtime. All of them produce the same
+output: a stable JSON envelope (schema v1) with the password, entropy,
+and crack-time estimate against a nation-state attacker.
+
+| Language | Path                            | Strategy                                    |
+| -------- | ------------------------------- | ------------------------------------------- |
+| Go       | [`go/`](go/main.go)             | Native — calls `pkg/secretgen` directly     |
+| Python   | [`python/`](python/generate.py) | Subprocess to the `secretgenerator` CLI     |
+| Node.js  | [`node/`](node/generate.mjs)    | Subprocess via `child_process.execFileSync` |
+| Ruby     | [`ruby/`](ruby/generate.rb)     | Subprocess via `Open3.capture2`             |
+| Rust     | [`rust/`](rust/src/main.rs)     | Subprocess via `std::process::Command`      |
+| Bash     | [`bash/`](bash/generate.sh)     | Pipe the JSON through `jq`                  |
+
+The non-Go snippets all `--require-schema-version=1` so any future
+incompatible change at the CLI side fails loudly instead of silently
+mutating field shapes.
+
+## Prerequisites
+
+Install the CLI once with whichever method you prefer:
+
+```sh
+brew install rafaelperoco/tap/secretgenerator
+# or
+npm install -g @secretgenerator/cli
+# or
+go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest
+```
+
+## Run
+
+```sh
+go run ./examples/go
+python3 examples/python/generate.py
+node examples/node/generate.mjs
+ruby examples/ruby/generate.rb
+( cd examples/rust && cargo run )
+examples/bash/generate.sh
+```
+
+Each prints something like:
+
+```
+password: M)Eh8a!?gDWKK9xS:c6;3Wuz
+entropy:  156.9 bits
+crack:    2e+14 times the age of the universe (nation-state)
+```

--- a/examples/bash/generate.sh
+++ b/examples/bash/generate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Generate an auditable password from a shell script. The CLI prints a
+# stable JSON envelope (schema v1); we use `jq` to project the fields
+# we care about.
+#
+# This snippet pins the schema version with --require-schema-version=1
+# so a future incompatible change fails loudly instead of silently
+# changing field shapes.
+#
+# Install once:
+#   brew install rafaelperoco/tap/secretgenerator
+#   # or: npm install -g @secretgenerator/cli
+
+set -euo pipefail
+
+length="${1:-24}"
+
+result=$(secretgenerator password \
+  --json \
+  --require-schema-version=1 \
+  --show-crack-time \
+  --length "$length" \
+  --charset alphanum-symbols-v1)
+
+password=$(jq -r .password <<<"$result")
+entropy=$(jq -r '.entropy_bits | (.*10|round)/10' <<<"$result")
+crack=$(jq -r '.crack_time_estimates[] | select(.profile_id=="nation-state-v1") | .human_readable' <<<"$result")
+
+printf 'password: %s\n' "$password"
+printf 'entropy:  %s bits\n' "$entropy"
+printf 'crack:    %s (nation-state)\n' "$crack"

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -1,0 +1,41 @@
+// Generate an auditable password directly from Go using the public
+// pkg/secretgen API — no subprocess, no JSON parsing.
+//
+// This is the recommended path for Go callers because it returns
+// typed structs and matches the CLI's schema-v1 contract 1:1.
+//
+// Run from the repo root:
+//   go run ./examples/go
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/rafaelperoco/secretgenerator/pkg/secretgen"
+)
+
+func main() {
+	res, err := secretgen.Password(secretgen.PasswordOptions{
+		Length:          24,
+		CharsetID:       "alphanum-symbols-v1",
+		RequiredClasses: "lower,upper,digit,symbol",
+	})
+	if err != nil {
+		if errors.Is(err, secretgen.ErrBelowEntropyFloor) {
+			log.Fatalf("policy floor rejected the request: %v", err)
+		}
+		log.Fatal(err)
+	}
+
+	fmt.Printf("password: %s\n", res.Password)
+	fmt.Printf("entropy:  %.1f bits\n", res.EntropyBits)
+
+	for _, e := range secretgen.EstimateCrackTime(res.EntropyBits) {
+		if e.ProfileID == "nation-state-v1" {
+			fmt.Printf("crack:    %s (nation-state)\n", e.HumanReadable)
+			break
+		}
+	}
+}

--- a/examples/go/main.go
+++ b/examples/go/main.go
@@ -5,13 +5,15 @@
 // typed structs and matches the CLI's schema-v1 contract 1:1.
 //
 // Run from the repo root:
-//   go run ./examples/go
+//
+//	go run ./examples/go
 package main
 
 import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/rafaelperoco/secretgenerator/pkg/secretgen"
 )
@@ -29,7 +31,10 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Printf("password: %s\n", res.Password)
+	// In real code, hand res.Password to whatever consumes it (HTTP
+	// response, env var, secret manager) and never log it. We write to
+	// stdout directly here because this is a demo.
+	_, _ = os.Stdout.WriteString("password: " + res.Password + "\n")
 	fmt.Printf("entropy:  %.1f bits\n", res.EntropyBits)
 
 	for _, e := range secretgen.EstimateCrackTime(res.EntropyBits) {

--- a/examples/node/generate.mjs
+++ b/examples/node/generate.mjs
@@ -1,0 +1,37 @@
+// Generate an auditable password from Node.js by shelling out to
+// secretgenerator. The CLI prints a stable JSON envelope (schema v1).
+//
+// This snippet pins the schema version so any future incompatible
+// change fails loudly instead of silently changing field shapes.
+//
+// Install once:
+//   npm install -g @secretgenerator/cli
+//   # or: brew install rafaelperoco/tap/secretgenerator
+
+import { execFileSync } from "node:child_process";
+
+function generatePassword({ length = 24 } = {}) {
+  const out = execFileSync(
+    "secretgenerator",
+    [
+      "password",
+      "--json",
+      "--require-schema-version=1",
+      "--show-crack-time",
+      "--length",
+      String(length),
+      "--charset",
+      "alphanum-symbols-v1",
+    ],
+    { encoding: "utf8" },
+  );
+  return JSON.parse(out);
+}
+
+const result = generatePassword({ length: 24 });
+console.log(`password: ${result.password}`);
+console.log(`entropy:  ${result.entropy_bits.toFixed(1)} bits`);
+const ns = result.crack_time_estimates.find(
+  (e) => e.profile_id === "nation-state-v1",
+);
+console.log(`crack:    ${ns.human_readable} (nation-state)`);

--- a/examples/python/generate.py
+++ b/examples/python/generate.py
@@ -1,0 +1,47 @@
+"""Generate an auditable password by shelling out to secretgenerator.
+
+The CLI prints a stable JSON envelope (schema v1). This wrapper pins the
+schema version so any future incompatible change at the CLI side fails
+loudly here instead of silently changing field shapes.
+
+Install once:
+    npm install -g @secretgenerator/cli
+    # or: brew install rafaelperoco/tap/secretgenerator
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+
+def generate_password(length: int = 24) -> dict:
+    proc = subprocess.run(
+        [
+            "secretgenerator",
+            "password",
+            "--json",
+            "--require-schema-version=1",
+            "--show-crack-time",
+            "--length",
+            str(length),
+            "--charset",
+            "alphanum-symbols-v1",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(proc.stdout)
+
+
+if __name__ == "__main__":
+    result = generate_password(length=24)
+    print(f"password: {result['password']}")
+    print(f"entropy:  {result['entropy_bits']:.1f} bits")
+    nation_state = next(
+        e for e in result["crack_time_estimates"] if e["profile_id"] == "nation-state-v1"
+    )
+    print(f"crack:    {nation_state['human_readable']} (nation-state)")
+    sys.exit(0)

--- a/examples/ruby/generate.rb
+++ b/examples/ruby/generate.rb
@@ -1,0 +1,31 @@
+# Generate an auditable password from Ruby by shelling out to
+# secretgenerator. The CLI prints a stable JSON envelope (schema v1).
+#
+# This snippet pins the schema version so any future incompatible
+# change fails loudly instead of silently changing field shapes.
+#
+# Install once:
+#   brew install rafaelperoco/tap/secretgenerator
+#   # or: npm install -g @secretgenerator/cli
+
+require "json"
+require "open3"
+
+def generate_password(length: 24)
+  stdout, status = Open3.capture2(
+    "secretgenerator", "password",
+    "--json",
+    "--require-schema-version=1",
+    "--show-crack-time",
+    "--length", length.to_s,
+    "--charset", "alphanum-symbols-v1"
+  )
+  raise "secretgenerator exited #{status.exitstatus}" unless status.success?
+  JSON.parse(stdout)
+end
+
+result = generate_password(length: 24)
+puts "password: #{result['password']}"
+puts "entropy:  #{result['entropy_bits'].round(1)} bits"
+nation_state = result["crack_time_estimates"].find { |e| e["profile_id"] == "nation-state-v1" }
+puts "crack:    #{nation_state['human_readable']} (nation-state)"

--- a/examples/rust/.gitignore
+++ b/examples/rust/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "secretgenerator-rust-example"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,0 +1,60 @@
+//! Generate an auditable password from Rust by shelling out to
+//! secretgenerator. The CLI prints a stable JSON envelope (schema v1).
+//!
+//! This snippet pins the schema version with `--require-schema-version=1`
+//! so a future incompatible change fails loudly instead of silently
+//! changing field shapes.
+//!
+//! Install once:
+//!     brew install rafaelperoco/tap/secretgenerator
+//!     # or: npm install -g @secretgenerator/cli
+
+use std::process::Command;
+
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+struct CrackTimeEstimate {
+    profile_id: String,
+    human_readable: String,
+}
+
+#[derive(Deserialize)]
+struct Output {
+    password: String,
+    entropy_bits: f64,
+    crack_time_estimates: Vec<CrackTimeEstimate>,
+}
+
+fn generate_password(length: u32) -> std::io::Result<Output> {
+    let out = Command::new("secretgenerator")
+        .args([
+            "password",
+            "--json",
+            "--require-schema-version=1",
+            "--show-crack-time",
+            "--length",
+            &length.to_string(),
+            "--charset",
+            "alphanum-symbols-v1",
+        ])
+        .output()?;
+    if !out.status.success() {
+        return Err(std::io::Error::other(String::from_utf8_lossy(&out.stderr).to_string()));
+    }
+    serde_json::from_slice(&out.stdout).map_err(std::io::Error::other)
+}
+
+fn main() -> std::io::Result<()> {
+    let r = generate_password(24)?;
+    println!("password: {}", r.password);
+    println!("entropy:  {:.1} bits", r.entropy_bits);
+    if let Some(ns) = r
+        .crack_time_estimates
+        .iter()
+        .find(|e| e.profile_id == "nation-state-v1")
+    {
+        println!("crack:    {} (nation-state)", ns.human_readable);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Closes part of #13.

Adds `examples/` with one runnable snippet per common runtime (Python, Node, Ruby, Rust, Bash, Go). All non-Go snippets shell out to the `secretgenerator` CLI and pin `--require-schema-version=1`; the Go snippet calls `pkg/secretgen` directly.

Each snippet prints the same three lines (password, entropy bits, nation-state crack time) so they help an AI agent or developer pick the snippet for their language with zero ambiguity about expected output.

All six were verified against the v2.0.0 binary on macOS arm64 before opening this PR.