### PR TITLE
docs: run prettier on all markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Built binaries (never commit)
 cmd/secretgenerator/secretgenerator
+
+# Rust example artifacts
+examples/rust/target/
+examples/rust/Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,8 +110,8 @@ backwards compatible with v1.**
 
 ### Migration from v1
 
-| v1                     | v2                                                        |
-| ---------------------- | --------------------------------------------------------- |
+| v1                     | v2                                                           |
+| ---------------------- | ------------------------------------------------------------ |
 | `pwdgen`               | `secretgenerator`                                            |
 | `pwdgen -l -n 20`      | `secretgenerator -c alphanum-v1 -n 20`                       |
 | `pwdgen -s -n 20`      | `secretgenerator -c alphanum-symbols-v1 -n 20`               |

--- a/README.md
+++ b/README.md
@@ -58,14 +58,14 @@ Pin the schema with `--require-schema-version=1`.
 
 ## Subcommands
 
-| Subcommand   | Use case                                                                               |
-| ------------ | -------------------------------------------------------------------------------------- |
-| `password`   | Random password from a named charset (default 20 chars, ~119 bits).                    |
-| `passphrase` | Diceware passphrase from the EFF Large Wordlist (default 8 words, ~103 bits).          |
+| Subcommand   | Use case                                                                                |
+| ------------ | --------------------------------------------------------------------------------------- |
+| `password`   | Random password from a named charset (default 20 chars, ~119 bits).                     |
+| `passphrase` | Diceware passphrase from the EFF Large Wordlist (default 8 words, ~103 bits).           |
 | `secret`     | Raw bytes from the OS CSPRNG, encoded as URL-safe base64 (default 32 bytes / 256 bits). |
-| `api-key`    | Token in `prefix_random` form (Stripe-style).                                          |
-| `pin`        | Numeric PIN with weak-PIN blocklist enforced.                                          |
-| `entropy`    | Estimate the entropy and crack time of an existing password.                           |
+| `api-key`    | Token in `prefix_random` form (Stripe-style).                                           |
+| `pin`        | Numeric PIN with weak-PIN blocklist enforced.                                           |
+| `entropy`    | Estimate the entropy and crack time of an existing password.                            |
 
 ```sh
 secretgenerator password --json --show-crack-time

--- a/cli/README.md
+++ b/cli/README.md
@@ -72,11 +72,11 @@ the certificate identity against
 
 ## Supported platforms
 
-| OS      | Architectures   |
-| ------- | --------------- |
-| Linux   | x64, arm64      |
-| macOS   | x64, arm64      |
-| Windows | x64             |
+| OS      | Architectures |
+| ------- | ------------- |
+| Linux   | x64, arm64    |
+| macOS   | x64, arm64    |
+| Windows | x64           |
 
 For other platforms, install from source:
 

--- a/docs/SCHEMA.md
+++ b/docs/SCHEMA.md
@@ -43,14 +43,14 @@ schema version.
 
 ### Optional (omitted when zero/empty)
 
-| Field                  | Type    | Description                                                                                                                                |
-| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `password`             | string  | The generated credential. Always present in `--json` output for generation subcommands; omitted for `entropy` (which consumes a password). |
-| `excluded_count`       | integer | Number of distinct runes the caller passed to `--exclude`.                                                                                 |
-| `excluded_sha256`      | string  | Hex-encoded SHA-256 of the `--exclude` argument. Lets audit logs correlate exclusion sets without echoing them.                            |
-| `required_classes`     | string  | Comma-separated list of character classes the output is guaranteed to contain (or, for `entropy`, observed in the input).                  |
-| `warnings`             | array   | Strings describing non-fatal advisories (e.g. when `--allow-weak` bypassed the floor or when a compatibility flag was used).               |
-| `crack_time_estimates` | array   | Opt-in (set with `--show-crack-time`). Time-to-break estimates under named attacker profiles.                                              |
+| Field                  | Type    | Description                                                                                                                                 |
+| ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `password`             | string  | The generated credential. Always present in `--json` output for generation subcommands; omitted for `entropy` (which consumes a password).  |
+| `excluded_count`       | integer | Number of distinct runes the caller passed to `--exclude`.                                                                                  |
+| `excluded_sha256`      | string  | Hex-encoded SHA-256 of the `--exclude` argument. Lets audit logs correlate exclusion sets without echoing them.                             |
+| `required_classes`     | string  | Comma-separated list of character classes the output is guaranteed to contain (or, for `entropy`, observed in the input).                   |
+| `warnings`             | array   | Strings describing non-fatal advisories (e.g. when `--allow-weak` bypassed the floor or when a compatibility flag was used).                |
+| `crack_time_estimates` | array   | Opt-in (set with `--show-crack-time`). Time-to-break estimates under named attacker profiles.                                               |
 | `error`                | object  | Present only on the failure path. Carries a stable `code` (e.g. `E_ENTROPY_TOO_LOW`), an English `message`, and an optional curated `hint`. |
 
 ### Audit log additions
@@ -106,13 +106,13 @@ agents see exactly one machine-readable artifact.
 Codes are stable strings; agents should branch on these rather than parse
 the message or rely on integer exit codes:
 
-| code                  | exit | meaning                                                                                              |
-| --------------------- | ---: | ---------------------------------------------------------------------------------------------------- |
-| `E_INVALID_ARGS`      |    2 | Unknown flag, unknown charset, schema-version mismatch, audit-log write failure, malformed stdin     |
-| `E_ENTROPY_TOO_LOW`   |    3 | Computed entropy is below `--min-entropy-bits` and `--allow-weak` was not set                        |
-| `E_RNG_FAILURE`       |    4 | OS entropy source returned an error mid-generation                                                   |
-| `E_CHARSET_EMPTY`     |    5 | `--exclude` reduced the charset below the minimum 2 runes                                            |
-| `E_CLASS_IMPOSSIBLE`  |    6 | `--require-classes` cannot be satisfied (charset lacks the class, or length < class count)           |
+| code                 | exit | meaning                                                                                          |
+| -------------------- | ---: | ------------------------------------------------------------------------------------------------ |
+| `E_INVALID_ARGS`     |    2 | Unknown flag, unknown charset, schema-version mismatch, audit-log write failure, malformed stdin |
+| `E_ENTROPY_TOO_LOW`  |    3 | Computed entropy is below `--min-entropy-bits` and `--allow-weak` was not set                    |
+| `E_RNG_FAILURE`      |    4 | OS entropy source returned an error mid-generation                                               |
+| `E_CHARSET_EMPTY`    |    5 | `--exclude` reduced the charset below the minimum 2 runes                                        |
+| `E_CLASS_IMPOSSIBLE` |    6 | `--require-classes` cannot be satisfied (charset lacks the class, or length < class count)       |
 
 Each code has a curated one-line `hint` documenting the typical fix.
 Hints are advisory and may be empty for codes added in future versions.

--- a/docs/SUBCOMMANDS.md
+++ b/docs/SUBCOMMANDS.md
@@ -16,13 +16,13 @@ floor; all share the same output schema and audit-log format.
 
 All generation subcommands share these flags via `addCommonFlags`:
 
-| Flag                           | Purpose                                                                                            |
-| ------------------------------ | -------------------------------------------------------------------------------------------------- |
-| `--json`                       | Emit a structured schema-v1 JSON record on stdout.                                                 |
-| `--audit-log <path>`           | Append a redacted JSONL audit record to `<path>` (mode 0600).                                      |
-| `--stdin-params`               | Read flags as a JSON object from stdin instead of argv. Avoids leaking sensitive flags to `ps(1)`. |
-| `--require-schema-version <n>` | Fail with exit code 2 unless the binary's output schema matches `<n>`.                             |
-| `--show-crack-time`            | Include `crack_time_estimates` in the JSON output and a human-readable summary in plain mode.      |
+| Flag                           | Purpose                                                                                                                                                                                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--json`                       | Emit a structured schema-v1 JSON record on stdout.                                                                                                                                                                                                                        |
+| `--audit-log <path>`           | Append a redacted JSONL audit record to `<path>` (mode 0600).                                                                                                                                                                                                             |
+| `--stdin-params`               | Read flags as a JSON object from stdin instead of argv. Avoids leaking sensitive flags to `ps(1)`.                                                                                                                                                                        |
+| `--require-schema-version <n>` | Fail with exit code 2 unless the binary's output schema matches `<n>`.                                                                                                                                                                                                    |
+| `--show-crack-time`            | Include `crack_time_estimates` in the JSON output and a human-readable summary in plain mode.                                                                                                                                                                             |
 | `--help-json`                  | Emit a machine-readable JSON description of the command and its flags, then exit. Persistent on the root, available on every subcommand. Output mirrors the OpenAPI parameter shape so agents already familiar with OpenAPI can introspect without learning a new schema. |
 
 ## Exit codes
@@ -48,7 +48,7 @@ Generates a random password from a named charset.
 | Flag                 | Default       | Notes                                                                                                                                             |
 | -------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-n, --length`       | 20            | Length of the password in characters.                                                                                                             |
-| `-c, --charset`      | `alphanum-v1` | One of the named charsets (see `secretgenerator -h` for the full list).                                                                              |
+| `-c, --charset`      | `alphanum-v1` | One of the named charsets (see `secretgenerator -h` for the full list).                                                                           |
 | `-e, --exclude`      | (none)        | Runes to remove from the charset _before_ generation. v1 had a bug where exclusion happened post-generation, shrinking the output; v2 fixes this. |
 | `--require-classes`  | (none)        | Comma-separated `lower,upper,digit,symbol`. Generation uses rejection sampling until all required classes are present.                            |
 | `--min-entropy-bits` | 80            | Floor the computed entropy must clear. Set to 0 to disable.                                                                                       |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -45,16 +45,16 @@ bundle); subsequent invocations are cached.
 
 ## Tools exposed
 
-| tool                     | when to use                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `generate_password`      | general-purpose passwords, named charsets                |
+| tool                     | when to use                                                      |
+| ------------------------ | ---------------------------------------------------------------- |
+| `generate_password`      | general-purpose passwords, named charsets                        |
 | `generate_passphrase`    | human-memorable secrets, EFF Large Wordlist (8 words ≈ 103 bits) |
-| `generate_secret`        | API tokens, OAuth secrets, JWT keys (recommended for agents) |
-| `generate_api_key`       | `prefix_base62` Stripe-style tokens                      |
-| `generate_pin`           | numeric PINs with weak-pattern rejection                 |
-| `assess_entropy`         | estimate strength of an existing password                |
-| `list_attacker_profiles` | enumerate the 5 named cracking-rate scenarios            |
-| `estimate_crack_time`    | time-to-break under each attacker profile                |
+| `generate_secret`        | API tokens, OAuth secrets, JWT keys (recommended for agents)     |
+| `generate_api_key`       | `prefix_base62` Stripe-style tokens                              |
+| `generate_pin`           | numeric PINs with weak-pattern rejection                         |
+| `assess_entropy`         | estimate strength of an existing password                        |
+| `list_attacker_profiles` | enumerate the 5 named cracking-rate scenarios                    |
+| `estimate_crack_time`    | time-to-break under each attacker profile                        |
 
 Each `generate_*` tool returns a [schema-v1 JSON record](https://secretgenerator.org/schemas/output-v1.json):
 


### PR DESCRIPTION
Pure formatting pass with `npx prettier --write` over every tracked `.md`. No semantic changes.