### PR TITLE
ci: add setup-secretgenerator composite action

### DIFF
--- a/.github/actions/setup-secretgenerator/README.md
+++ b/.github/actions/setup-secretgenerator/README.md
@@ -1,0 +1,49 @@
+# setup-secretgenerator
+
+GitHub Action that installs the auditable
+[`secretgenerator`](https://github.com/rafaelperoco/secretgenerator) CLI on
+the runner, verifies its cosign keyless signature and SHA-256 checksum,
+and exposes it on `PATH`.
+
+Works on `ubuntu-*`, `macos-*`, and `windows-*` runners (amd64 and
+arm64). Internally a composite action — no Node.js, no Docker, just
+`curl`, `cosign`, and `tar`/`unzip`.
+
+## Usage
+
+```yaml
+- uses: rafaelperoco/secretgenerator/.github/actions/setup-secretgenerator@v2.0.0
+  with:
+    version: v2.0.0 # or "latest" (default)
+
+- run: secretgenerator password --json --require-schema-version=1
+```
+
+Pin the action by tag (`@v2.0.0`) or, for stricter supply-chain hygiene,
+by commit SHA.
+
+## Inputs
+
+| Name            | Default  | Description                                                                                             |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `version`       | `latest` | Release tag to install (`v2.0.0`, `latest`). `latest` skips prereleases.                                |
+| `verify-cosign` | `"true"` | When `"true"`, verifies the cosign keyless signature on `checksums.txt`. Installs `cosign` when absent. |
+
+## Outputs
+
+| Name      | Description                               |
+| --------- | ----------------------------------------- |
+| `version` | The resolved release tag (e.g. `v2.0.0`). |
+| `bin`     | Absolute path to the installed binary.    |
+
+## What it verifies
+
+1. Cosign keyless signature on `checksums.txt` (Sigstore / Fulcio +
+   GitHub OIDC). The certificate identity must be issued from
+   `https://github.com/rafaelperoco/secretgenerator/.github/workflows/release.yml`
+   and the OIDC issuer must be GitHub Actions.
+2. SHA-256 of the platform archive matches the entry in `checksums.txt`.
+3. A live smoke test: a 16-character password is generated and the
+   schema-v1 envelope is parsed.
+
+If any step fails the job fails — there is no soft mode.

--- a/.github/actions/setup-secretgenerator/action.yml
+++ b/.github/actions/setup-secretgenerator/action.yml
@@ -1,0 +1,158 @@
+name: Setup secretgenerator
+description: |
+  Install the auditable secretgenerator CLI on a runner and verify the
+  binary against its cosign signature and SHA-256 checksum. Supports
+  ubuntu, macos, and windows runners on amd64 and arm64.
+
+branding:
+  icon: lock
+  color: purple
+
+inputs:
+  version:
+    description: |
+      Release tag to install (e.g. "v2.0.0"). Use "latest" to follow the
+      latest non-prerelease tag.
+    required: false
+    default: latest
+  verify-cosign:
+    description: |
+      Whether to verify the cosign keyless signature on checksums.txt
+      before extracting the binary. Requires cosign on PATH; the action
+      installs it via sigstore/cosign-installer when missing.
+    required: false
+    default: "true"
+
+outputs:
+  version:
+    description: The resolved release tag (e.g. "v2.0.0").
+    value: ${{ steps.resolve.outputs.version }}
+  bin:
+    description: Absolute path to the installed secretgenerator binary.
+    value: ${{ steps.install.outputs.bin }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve version
+      id: resolve
+      shell: bash
+      env:
+        REQUESTED: ${{ inputs.version }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+        if [ "$REQUESTED" = "latest" ]; then
+          # Skip prereleases so users on the default input never land on
+          # an alpha/beta tag.
+          version=$(gh release list \
+            --repo rafaelperoco/secretgenerator \
+            --exclude-pre-releases \
+            --exclude-drafts \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName')
+        else
+          version="$REQUESTED"
+        fi
+        if [ -z "$version" ]; then
+          echo "::error::could not resolve secretgenerator version"
+          exit 1
+        fi
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+        echo "secretgenerator version: $version"
+
+    - name: Install cosign
+      if: inputs.verify-cosign == 'true'
+      uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+      with:
+        cosign-release: v2.4.1
+
+    - name: Download and verify
+      id: install
+      shell: bash
+      env:
+        VERSION: ${{ steps.resolve.outputs.version }}
+        VERIFY_COSIGN: ${{ inputs.verify-cosign }}
+      run: |
+        set -euo pipefail
+
+        # Map runner OS/arch to goreleaser archive naming.
+        case "$RUNNER_OS" in
+          Linux)   os=linux ;;
+          macOS)   os=darwin ;;
+          Windows) os=windows ;;
+          *) echo "::error::unsupported RUNNER_OS=$RUNNER_OS" >&2; exit 1 ;;
+        esac
+        case "$RUNNER_ARCH" in
+          X64)   arch=amd64 ;;
+          ARM64) arch=arm64 ;;
+          *) echo "::error::unsupported RUNNER_ARCH=$RUNNER_ARCH" >&2; exit 1 ;;
+        esac
+
+        # Strip leading "v" because goreleaser archives use bare semver.
+        ver_no_v="${VERSION#v}"
+
+        if [ "$os" = "windows" ]; then
+          archive="secretgenerator_${ver_no_v}_${os}_${arch}.zip"
+        else
+          archive="secretgenerator_${ver_no_v}_${os}_${arch}.tar.gz"
+        fi
+
+        base="https://github.com/rafaelperoco/secretgenerator/releases/download/${VERSION}"
+        workdir="${RUNNER_TEMP}/secretgenerator-${VERSION}"
+        mkdir -p "$workdir"
+        cd "$workdir"
+
+        echo "::group::Downloading artifacts"
+        curl --fail --show-error --silent --location -o "$archive"        "${base}/${archive}"
+        curl --fail --show-error --silent --location -o checksums.txt     "${base}/checksums.txt"
+        if [ "$VERIFY_COSIGN" = "true" ]; then
+          curl --fail --show-error --silent --location -o checksums.txt.sig "${base}/checksums.txt.sig"
+          curl --fail --show-error --silent --location -o checksums.txt.pem "${base}/checksums.txt.pem"
+        fi
+        echo "::endgroup::"
+
+        if [ "$VERIFY_COSIGN" = "true" ]; then
+          echo "::group::Verifying cosign keyless signature"
+          cosign verify-blob \
+            --certificate checksums.txt.pem \
+            --signature checksums.txt.sig \
+            --certificate-identity-regexp "^https://github.com/rafaelperoco/secretgenerator/.github/workflows/release.yml@refs/tags/v" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            checksums.txt
+          echo "::endgroup::"
+        fi
+
+        echo "::group::Verifying SHA-256 checksum"
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          shasum -a 256 -c checksums.txt --ignore-missing
+        elif [ "$RUNNER_OS" = "Windows" ]; then
+          # Windows runners ship git-bash with sha256sum.
+          sha256sum -c checksums.txt --ignore-missing
+        else
+          sha256sum -c checksums.txt --ignore-missing
+        fi
+        echo "::endgroup::"
+
+        echo "::group::Extracting"
+        if [ "$os" = "windows" ]; then
+          unzip -q "$archive"
+          binname=secretgenerator.exe
+        else
+          tar -xzf "$archive"
+          binname=secretgenerator
+        fi
+        bindir="${RUNNER_TOOL_CACHE}/secretgenerator/${ver_no_v}"
+        mkdir -p "$bindir"
+        mv "$binname" "$bindir/"
+        chmod +x "$bindir/$binname" 2>/dev/null || true
+        echo "$bindir" >> "$GITHUB_PATH"
+        echo "bin=${bindir}/${binname}" >> "$GITHUB_OUTPUT"
+        echo "::endgroup::"
+
+        echo "::group::Smoke"
+        "$bindir/$binname" password --json --length 16 --charset alphanum-v1 --json --require-schema-version=1 \
+          | head -c 200
+        echo
+        echo "::endgroup::"

--- a/.github/workflows/action-smoke.yml
+++ b/.github/workflows/action-smoke.yml
@@ -1,0 +1,67 @@
+name: action-smoke
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/actions/setup-secretgenerator/**"
+      - ".github/workflows/action-smoke.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/actions/setup-secretgenerator/**"
+      - ".github/workflows/action-smoke.yml"
+  schedule:
+    # Re-run weekly so a release-pipeline regression that breaks
+    # checksum/cosign download surfaces without a code change.
+    - cron: "37 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: install + smoke
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Run setup-secretgenerator (latest)
+        id: setup
+        uses: ./.github/actions/setup-secretgenerator
+        with:
+          version: latest
+          verify-cosign: "true"
+
+      - name: Generate a password and parse JSON
+        shell: bash
+        run: |
+          set -euo pipefail
+          out=$(secretgenerator password \
+            --json \
+            --length 24 \
+            --charset alphanum-symbols-v1 \
+            --require-schema-version=1)
+          echo "$out" | head -c 300; echo
+          # The CLI must emit schema_version=1 and a non-empty password.
+          # Use jq if available; otherwise fall back to grep.
+          if command -v jq >/dev/null 2>&1; then
+            sv=$(jq -r .schema_version <<<"$out")
+            pw=$(jq -r .password <<<"$out")
+          else
+            sv=$(grep -oE '"schema_version"[[:space:]]*:[[:space:]]*[0-9]+' <<<"$out" | head -1 | grep -oE '[0-9]+$')
+            pw=$(grep -oE '"password"[[:space:]]*:[[:space:]]*"[^"]+"' <<<"$out" | head -1 | sed 's/.*: *"//; s/"$//')
+          fi
+          [ "$sv" = "1" ]
+          [ "${#pw}" = "24" ]
+          echo "ok: schema $sv, password length ${#pw}"
+
+      - name: Print resolved version and bin path
+        shell: bash
+        run: |
+          echo "resolved version: ${{ steps.setup.outputs.version }}"
+          echo "binary path:      ${{ steps.setup.outputs.bin }}"

--- a/README.md
+++ b/README.md
@@ -80,14 +80,15 @@ Full flag reference: [docs/SUBCOMMANDS.md](docs/SUBCOMMANDS.md).
 
 ## Install
 
-| Method                 | Command                                                                         |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| **npm (zero-install)** | `npx -y @secretgenerator/cli`                                                   |
-| **Homebrew**           | `brew install rafaelperoco/tap/secretgenerator`                                 |
-| **MCP server**         | `npx -y @secretgenerator/mcp`                                                   |
-| **Container**          | `docker run --rm ghcr.io/rafaelperoco/secretgenerator:v2.0.0`                   |
-| **Go install**         | `go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@v2.0.0` |
-| **Verified manual**    | See [verified install](#verified-install) below.                                |
+| Method                 | Command                                                                           |
+| ---------------------- | --------------------------------------------------------------------------------- |
+| **npm (zero-install)** | `npx -y @secretgenerator/cli`                                                     |
+| **Homebrew**           | `brew install rafaelperoco/tap/secretgenerator`                                   |
+| **MCP server**         | `npx -y @secretgenerator/mcp`                                                     |
+| **Container**          | `docker run --rm ghcr.io/rafaelperoco/secretgenerator:v2.0.0`                     |
+| **Go install**         | `go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@v2.0.0`   |
+| **GitHub Actions**     | `uses: rafaelperoco/secretgenerator/.github/actions/setup-secretgenerator@v2.0.0` |
+| **Verified manual**    | See [verified install](#verified-install) below.                                  |
 
 ### Verified install
 


### PR DESCRIPTION
Closes part of #13.

Adds a reusable composite GitHub Action at `.github/actions/setup-secretgenerator/` that downloads the right archive for the runner, verifies the cosign keyless signature on `checksums.txt` (Sigstore/Fulcio + GitHub OIDC), checks the SHA-256, extracts, and adds the binary to `PATH`.

Why composite (not Node):
- No build step, no `dist/` to commit.
- Versioning rides on the repo tag — users pin `@v2.0.0` and the action is guaranteed to install the matching CLI binary.
- Marketplace publishing still works the same.

Includes a matrix smoke workflow (`action-smoke`) that runs the action on ubuntu/macos/windows and verifies the schema-v1 contract end-to-end. Also runs weekly to catch release-pipeline regressions that break checksum/cosign download.