### PR TITLE
feat: add PyPI and crates.io wrappers

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,49 @@
+name: python-ci
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "python/**"
+      - ".github/workflows/python-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "python/**"
+      - ".github/workflows/python-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: pytest (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: python
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install secretgenerator CLI from latest release
+        uses: ./.github/actions/setup-secretgenerator
+        with:
+          version: latest
+          verify-cosign: "false"
+
+      - name: Install package
+        run: |
+          python -m pip install --upgrade pip build hatchling pytest
+          python -m pip install -e .
+
+      - name: Test
+        run: pytest -q

--- a/.github/workflows/rust-crate-ci.yml
+++ b/.github/workflows/rust-crate-ci.yml
@@ -1,0 +1,51 @@
+name: rust-crate-ci
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust-crate/**"
+      - ".github/workflows/rust-crate-ci.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "rust-crate/**"
+      - ".github/workflows/rust-crate-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: cargo (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: rust-crate
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install secretgenerator CLI from latest release
+        uses: ./.github/actions/setup-secretgenerator
+        with:
+          version: latest
+          verify-cosign: "false"
+
+      - name: cargo build
+        run: cargo build --verbose
+
+      - name: cargo build --example quickstart
+        run: cargo build --example quickstart
+
+      - name: cargo run --example quickstart
+        run: cargo run --example quickstart
+
+      - name: cargo fmt --check
+        run: cargo fmt --all -- --check
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,15 @@ cmd/secretgenerator/secretgenerator
 # Rust example artifacts
 examples/rust/target/
 examples/rust/Cargo.lock
+
+# Rust crate artifacts
+rust-crate/target/
+rust-crate/Cargo.lock
+
+# Python build artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.pytest_cache/
+.venv/

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Full flag reference: [docs/SUBCOMMANDS.md](docs/SUBCOMMANDS.md).
 | **Container**          | `docker run --rm ghcr.io/rafaelperoco/secretgenerator:v2.0.0`                     |
 | **Go install**         | `go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@v2.0.0`   |
 | **GitHub Actions**     | `uses: rafaelperoco/secretgenerator/.github/actions/setup-secretgenerator@v2.0.0` |
+| **Python (PyPI)**      | `pip install secretgenerator` (CLI binary installed separately)                   |
+| **Rust (crates.io)**   | `cargo add secretgenerator` (CLI binary installed separately)                     |
 | **Verified manual**    | See [verified install](#verified-install) below.                                  |
 
 ### Verified install

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,73 @@
+# secretgenerator (Python)
+
+[![pypi](https://img.shields.io/pypi/v/secretgenerator)](https://pypi.org/project/secretgenerator/)
+[![python](https://img.shields.io/pypi/pyversions/secretgenerator)](https://pypi.org/project/secretgenerator/)
+
+Auditable random credential generator for AI agents and machine-readable
+pipelines. This Python package wraps the
+[`secretgenerator`](https://github.com/rafaelperoco/secretgenerator) CLI
+and exposes its stable schema-v1 JSON output as Python dicts.
+
+## Install
+
+The Python package and the CLI binary install separately:
+
+```sh
+pip install secretgenerator
+```
+
+Then install the CLI once with whichever method fits your environment:
+
+```sh
+npm install -g @secretgenerator/cli
+# or
+brew install rafaelperoco/tap/secretgenerator
+# or
+go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest
+```
+
+## Quick start
+
+```python
+import secretgenerator as sg
+
+pw = sg.password(length=24, charset="alphanum-symbols-v1",
+                 require_classes="lower,upper,digit,symbol")
+print(pw["password"], "—", pw["entropy_bits"], "bits")
+
+phrase = sg.passphrase(words=8, separator="-")
+print(phrase["password"])
+
+token = sg.api_key(length=40, prefix="sk_live")
+print(token["password"])
+
+bits = sg.entropy("Tr0ub4dor&3")["entropy_bits"]
+print(f"that pasword has {bits:.1f} bits")
+```
+
+Every function returns a parsed schema-v1 dict with the same shape as
+the CLI's `--json` output (see
+[`schemas/output-v1.json`](https://github.com/rafaelperoco/secretgenerator/blob/main/schemas/output-v1.json)).
+
+## Error handling
+
+```python
+try:
+    sg.password(length=4)  # below the 80-bit floor
+except sg.SecretgeneratorError as e:
+    if e.code == "E_ENTROPY_TOO_LOW":
+        # Stable code; safe to branch on.
+        ...
+```
+
+The `code` attribute exposes a stable identifier from the CLI's error
+envelope (`E_ENTROPY_TOO_LOW`, `E_CHARSET_EMPTY`, `E_CLASS_IMPOSSIBLE`,
+`E_INVALID_ARGS`, `E_RNG_FAILURE`).
+
+## Why a wrapper instead of a pure-Python implementation?
+
+Cryptographic primitives belong in audited binaries with reproducible
+builds and SLSA provenance, not duplicated across language wrappers.
+The CLI is signed end-to-end with cosign keyless (Sigstore/Fulcio +
+GitHub OIDC) and ships SLSA Level 3 attestation. This wrapper is a
+thin transport — it parses JSON.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "secretgenerator"
+version = "2.0.0"
+description = "Auditable random credential generator for AI agents and machine-readable pipelines."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "Rafael Peroco" }]
+keywords = [
+  "secret-generation",
+  "password-generator",
+  "csprng",
+  "auditable",
+  "sigstore",
+  "slsa",
+  "cosign",
+  "ai-agents",
+  "mcp",
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Security",
+  "Topic :: Security :: Cryptography",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[project.urls]
+Homepage = "https://secretgenerator.org"
+Documentation = "https://github.com/rafaelperoco/secretgenerator#readme"
+Repository = "https://github.com/rafaelperoco/secretgenerator"
+Changelog = "https://github.com/rafaelperoco/secretgenerator/blob/main/CHANGELOG.md"
+Issues = "https://github.com/rafaelperoco/secretgenerator/issues"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/secretgenerator"]
+
+[tool.hatch.build.targets.sdist]
+include = ["src/", "tests/", "README.md", "LICENSE"]

--- a/python/src/secretgenerator/__init__.py
+++ b/python/src/secretgenerator/__init__.py
@@ -1,0 +1,47 @@
+"""Auditable random credential generation backed by the secretgenerator CLI.
+
+The Python package is a thin wrapper around the CLI's stable schema-v1
+JSON contract: each function shells out to ``secretgenerator``, parses
+the JSON envelope, and returns it as a dict. Use the CLI directly when
+you need exotic flags; use this module when you want idiomatic Python.
+
+Install the binary once with whichever method you prefer:
+
+    npm install -g @secretgenerator/cli
+    # or: brew install rafaelperoco/tap/secretgenerator
+    # or: download from https://github.com/rafaelperoco/secretgenerator/releases
+
+All functions raise :class:`SecretgeneratorError` when the binary exits
+non-zero, with the structured JSON error envelope attached as
+``error.envelope`` so callers can branch on stable error codes
+(``E_ENTROPY_TOO_LOW``, ``E_CHARSET_EMPTY``, ``E_CLASS_IMPOSSIBLE``, etc.)
+instead of parsing free-form messages.
+"""
+
+from __future__ import annotations
+
+from .api import (
+    SCHEMA_VERSION,
+    SecretgeneratorError,
+    api_key,
+    entropy,
+    estimate_crack_time,
+    passphrase,
+    password,
+    pin,
+    secret,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "SecretgeneratorError",
+    "api_key",
+    "entropy",
+    "estimate_crack_time",
+    "passphrase",
+    "password",
+    "pin",
+    "secret",
+]
+
+__version__ = "2.0.0"

--- a/python/src/secretgenerator/api.py
+++ b/python/src/secretgenerator/api.py
@@ -1,0 +1,292 @@
+"""Public Python API. Each function corresponds to a CLI subcommand.
+
+The functions return parsed schema-v1 dicts. Type hints describe the
+shape of the JSON envelope but the runtime type is always a plain
+``dict[str, Any]`` so consumers can opt into stricter parsing
+(pydantic, attrs, etc.) without paying for it here.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from typing import Any, Iterable
+
+SCHEMA_VERSION = 1
+
+
+class SecretgeneratorError(RuntimeError):
+    """Raised when the CLI exits non-zero.
+
+    When ``--json`` was set the CLI emits a structured envelope on
+    stderr; we expose it as :attr:`envelope` so callers branch on the
+    stable ``error.code`` rather than parsing free-form messages.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        returncode: int,
+        envelope: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.envelope = envelope
+
+    @property
+    def code(self) -> str | None:
+        """Stable error code (e.g. ``ENTROPY_TOO_LOW``) when present."""
+        if not self.envelope:
+            return None
+        err = self.envelope.get("error")
+        if isinstance(err, dict):
+            code = err.get("code")
+            return code if isinstance(code, str) else None
+        return None
+
+
+def _binary() -> str:
+    path = shutil.which("secretgenerator")
+    if path is None:
+        raise SecretgeneratorError(
+            "secretgenerator is not on PATH. Install it with one of:\n"
+            "  npm install -g @secretgenerator/cli\n"
+            "  brew install rafaelperoco/tap/secretgenerator\n"
+            "  go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest",
+            returncode=127,
+        )
+    return path
+
+
+def _run(args: Iterable[str]) -> dict[str, Any]:
+    cmd = [_binary(), *args]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        envelope: dict[str, Any] | None = None
+        for stream in (proc.stderr, proc.stdout):
+            if stream:
+                try:
+                    envelope = json.loads(stream)
+                    break
+                except json.JSONDecodeError:
+                    continue
+        raise SecretgeneratorError(
+            (proc.stderr or proc.stdout or f"exit code {proc.returncode}").strip(),
+            returncode=proc.returncode,
+            envelope=envelope,
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SecretgeneratorError(
+            f"could not parse JSON from CLI: {exc}",
+            returncode=proc.returncode,
+        ) from exc
+
+
+def _common(
+    *,
+    require_schema_version: int | None,
+    show_crack_time: bool,
+    audit_log: str | None,
+    extra: list[str],
+) -> list[str]:
+    args = ["--json", *extra]
+    if require_schema_version is not None:
+        args.append(f"--require-schema-version={require_schema_version}")
+    if show_crack_time:
+        args.append("--show-crack-time")
+    if audit_log:
+        args.extend(["--audit-log", audit_log])
+    return args
+
+
+def password(
+    *,
+    length: int = 20,
+    charset: str = "alphanum-v1",
+    require_classes: str | None = None,
+    exclude: str | None = None,
+    min_entropy_bits: float | None = None,
+    allow_weak: bool = False,
+    show_crack_time: bool = True,
+    audit_log: str | None = None,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Generate a random password."""
+    extra: list[str] = ["--length", str(length), "--charset", charset]
+    if require_classes:
+        extra.extend(["--require-classes", require_classes])
+    if exclude:
+        extra.extend(["--exclude", exclude])
+    if min_entropy_bits is not None:
+        extra.extend(["--min-entropy-bits", str(min_entropy_bits)])
+    if allow_weak:
+        extra.append("--allow-weak")
+    args = _common(
+        require_schema_version=require_schema_version,
+        show_crack_time=show_crack_time,
+        audit_log=audit_log,
+        extra=extra,
+    )
+    return _run(["password", *args])
+
+
+def passphrase(
+    *,
+    words: int = 8,
+    separator: str = "-",
+    capitalize: bool = False,
+    digit_suffix: bool = False,
+    min_entropy_bits: float | None = None,
+    allow_weak: bool = False,
+    show_crack_time: bool = True,
+    audit_log: str | None = None,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Generate an EFF Large Wordlist diceware passphrase."""
+    extra: list[str] = ["--words", str(words), "--separator", separator]
+    if capitalize:
+        extra.append("--capitalize")
+    if digit_suffix:
+        extra.append("--digit-suffix")
+    if min_entropy_bits is not None:
+        extra.extend(["--min-entropy-bits", str(min_entropy_bits)])
+    if allow_weak:
+        extra.append("--allow-weak")
+    args = _common(
+        require_schema_version=require_schema_version,
+        show_crack_time=show_crack_time,
+        audit_log=audit_log,
+        extra=extra,
+    )
+    return _run(["passphrase", *args])
+
+
+def secret(
+    *,
+    bytes_: int = 32,
+    prefix: str | None = None,
+    min_entropy_bits: float | None = None,
+    allow_weak: bool = False,
+    show_crack_time: bool = True,
+    audit_log: str | None = None,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Generate raw CSPRNG bytes encoded as URL-safe base64."""
+    extra: list[str] = ["--bytes", str(bytes_)]
+    if prefix:
+        extra.extend(["--prefix", prefix])
+    if min_entropy_bits is not None:
+        extra.extend(["--min-entropy-bits", str(min_entropy_bits)])
+    if allow_weak:
+        extra.append("--allow-weak")
+    args = _common(
+        require_schema_version=require_schema_version,
+        show_crack_time=show_crack_time,
+        audit_log=audit_log,
+        extra=extra,
+    )
+    return _run(["secret", *args])
+
+
+def api_key(
+    *,
+    length: int = 32,
+    prefix: str = "sk",
+    separator: str = "_",
+    min_entropy_bits: float | None = None,
+    allow_weak: bool = False,
+    show_crack_time: bool = True,
+    audit_log: str | None = None,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Generate a Stripe-style ``prefix_random`` token."""
+    extra: list[str] = [
+        "--length", str(length),
+        "--prefix", prefix,
+        "--separator", separator,
+    ]
+    if min_entropy_bits is not None:
+        extra.extend(["--min-entropy-bits", str(min_entropy_bits)])
+    if allow_weak:
+        extra.append("--allow-weak")
+    args = _common(
+        require_schema_version=require_schema_version,
+        show_crack_time=show_crack_time,
+        audit_log=audit_log,
+        extra=extra,
+    )
+    return _run(["api-key", *args])
+
+
+def pin(
+    *,
+    digits: int = 6,
+    acknowledge_low_entropy: bool = True,
+    allow_weak_pattern: bool = False,
+    show_crack_time: bool = False,
+    audit_log: str | None = None,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Generate a numeric PIN with the weak-pattern blocklist enforced.
+
+    PINs are intrinsically low-entropy (a 6-digit PIN carries ~19.9 bits)
+    and thus require an explicit acknowledgement. Set
+    ``acknowledge_low_entropy=False`` only if you have already shown the
+    user that warning elsewhere; the CLI will refuse otherwise.
+    """
+    extra: list[str] = ["--digits", str(digits)]
+    if acknowledge_low_entropy:
+        extra.append("--acknowledge-low-entropy")
+    if allow_weak_pattern:
+        extra.append("--allow-weak-pattern")
+    args = _common(
+        require_schema_version=require_schema_version,
+        show_crack_time=show_crack_time,
+        audit_log=audit_log,
+        extra=extra,
+    )
+    return _run(["pin", *args])
+
+
+def entropy(
+    candidate: str,
+    *,
+    show_crack_time: bool = True,
+    require_schema_version: int | None = SCHEMA_VERSION,
+) -> dict[str, Any]:
+    """Estimate the entropy and crack time of an existing string.
+
+    The candidate is piped on stdin; it never appears on the command
+    line, so it does not leak into ``ps``, shell history, or the
+    process-list inspection surface.
+    """
+    cmd = [_binary(), "entropy", "--json"]
+    if require_schema_version is not None:
+        cmd.append(f"--require-schema-version={require_schema_version}")
+    if show_crack_time:
+        cmd.append("--show-crack-time")
+    proc = subprocess.run(cmd, input=candidate, capture_output=True, text=True, check=False)
+    if proc.returncode != 0:
+        raise SecretgeneratorError(
+            (proc.stderr or proc.stdout or f"exit code {proc.returncode}").strip(),
+            returncode=proc.returncode,
+        )
+    return json.loads(proc.stdout)
+
+
+def estimate_crack_time(candidate: str) -> list[dict[str, Any]]:
+    """Return crack-time estimates for an existing string.
+
+    Convenience wrapper that calls :func:`entropy` with
+    ``show_crack_time=True`` and returns the ``crack_time_estimates``
+    list directly.
+    """
+    payload = entropy(candidate, show_crack_time=True)
+    estimates = payload.get("crack_time_estimates")
+    if not isinstance(estimates, list):
+        return []
+    return estimates

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1,0 +1,85 @@
+"""Smoke tests for the Python wrapper.
+
+These tests assume a working ``secretgenerator`` binary on PATH. CI
+provisions it via the composite action; locally, install via brew or
+``go install``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import secretgenerator as sg
+
+
+def test_password_returns_schema_v1() -> None:
+    out = sg.password(length=24, charset="alphanum-symbols-v1")
+    assert out["schema_version"] == 1
+    assert len(out["password"]) == 24
+    assert out["entropy_bits"] > 100
+    assert out["subcommand"] == "password"
+    assert out["request_id"]
+
+
+def test_password_required_classes_guarantee() -> None:
+    out = sg.password(
+        length=20,
+        charset="alphanum-symbols-v1",
+        require_classes="lower,upper,digit,symbol",
+    )
+    pw = out["password"]
+    assert any(c.islower() for c in pw)
+    assert any(c.isupper() for c in pw)
+    assert any(c.isdigit() for c in pw)
+    assert any(not c.isalnum() for c in pw)
+
+
+def test_passphrase_word_count() -> None:
+    out = sg.passphrase(words=8, separator=" ")
+    assert len(out["password"].split(" ")) == 8
+
+
+def test_secret_default_length() -> None:
+    out = sg.secret(bytes_=32)
+    # 32 bytes -> 43 base64url chars (no padding).
+    assert len(out["password"]) == 43
+
+
+def test_api_key_prefix() -> None:
+    out = sg.api_key(length=32, prefix="sk_test", separator="_")
+    assert out["password"].startswith("sk_test_")
+
+
+def test_pin_default() -> None:
+    out = sg.pin(digits=6)
+    assert out["password"].isdigit()
+    assert len(out["password"]) == 6
+
+
+def test_entropy_estimate() -> None:
+    out = sg.entropy("Tr0ub4dor&3")
+    assert out["entropy_bits"] > 0
+    assert "crack_time_estimates" in out
+
+
+def test_estimate_crack_time_helper() -> None:
+    estimates = sg.estimate_crack_time("Tr0ub4dor&3")
+    assert isinstance(estimates, list)
+    assert len(estimates) >= 5
+    profile_ids = {e["profile_id"] for e in estimates}
+    assert "nation-state-v1" in profile_ids
+
+
+def test_entropy_below_floor_raises() -> None:
+    with pytest.raises(sg.SecretgeneratorError) as excinfo:
+        # length 4 alphanum is ~24 bits, far below the 80-bit floor.
+        sg.password(length=4, charset="alphanum-v1")
+    err = excinfo.value
+    # The error envelope must carry the stable code.
+    assert err.code == "E_ENTROPY_TOO_LOW", err.envelope
+
+
+def test_schema_pinning_rejects_mismatch() -> None:
+    # Schema 999 does not exist; the CLI must refuse.
+    with pytest.raises(sg.SecretgeneratorError):
+        sg.password(length=24, charset="alphanum-v1", require_schema_version=999)

--- a/rust-crate/.gitignore
+++ b/rust-crate/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/rust-crate/Cargo.toml
+++ b/rust-crate/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "secretgenerator"
+version = "2.0.0"
+edition = "2024"
+rust-version = "1.85"
+description = "Auditable random credential generator for AI agents and machine-readable pipelines (wraps the secretgenerator CLI)."
+license = "MIT"
+homepage = "https://secretgenerator.org"
+documentation = "https://docs.rs/secretgenerator"
+repository = "https://github.com/rafaelperoco/secretgenerator"
+readme = "README.md"
+keywords = ["secret", "password", "csprng", "auditable", "sigstore"]
+categories = ["cryptography", "command-line-utilities", "api-bindings"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+# none — we exercise the library against a real CLI in CI.
+
+[[example]]
+name = "quickstart"
+path = "examples/quickstart.rs"

--- a/rust-crate/README.md
+++ b/rust-crate/README.md
@@ -1,0 +1,71 @@
+# secretgenerator
+
+[![crates.io](https://img.shields.io/crates/v/secretgenerator)](https://crates.io/crates/secretgenerator)
+[![docs.rs](https://docs.rs/secretgenerator/badge.svg)](https://docs.rs/secretgenerator)
+
+Rust bindings for the auditable
+[`secretgenerator`](https://github.com/rafaelperoco/secretgenerator) CLI.
+This crate is a thin transport layer: each function shells out to the
+binary, parses the schema-v1 JSON envelope, and returns a typed
+`Output`. Cryptographic primitives stay in the audited binary with
+SLSA Level 3 provenance and cosign keyless signatures; this crate just
+parses JSON.
+
+## Install
+
+The crate and the binary install separately:
+
+```sh
+cargo add secretgenerator
+```
+
+Then install the CLI once with whichever method fits your environment:
+
+```sh
+brew install rafaelperoco/tap/secretgenerator
+# or
+npm install -g @secretgenerator/cli
+# or
+go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest
+```
+
+## Quick start
+
+```rust
+use secretgenerator::{password, PasswordOptions};
+
+let out = password(
+    PasswordOptions::default()
+        .length(24)
+        .charset("alphanum-symbols-v1")
+        .require_classes("lower,upper,digit,symbol"),
+)?;
+println!("{} ({:.1} bits)", out.password, out.entropy_bits);
+# Ok::<_, secretgenerator::Error>(())
+```
+
+Run the full example with `cargo run --example quickstart`.
+
+## Error handling
+
+```rust
+use secretgenerator::{password, PasswordOptions, Error};
+
+match password(PasswordOptions::default().length(4)) {
+    Err(e) if e.cli_code() == Some("E_ENTROPY_TOO_LOW") => {
+        // Stable code; safe to branch on.
+    }
+    other => { /* ... */ let _ = other; }
+}
+```
+
+The CLI's stable error codes are `E_ENTROPY_TOO_LOW`,
+`E_CHARSET_EMPTY`, `E_CLASS_IMPOSSIBLE`, `E_INVALID_ARGS`, and
+`E_RNG_FAILURE`.
+
+## Why not pure Rust?
+
+Cryptographic primitives belong in audited binaries with reproducible
+builds and SLSA provenance, not duplicated across language wrappers.
+Verify any release end-to-end with the procedure in
+[docs/AUDIT.md](https://github.com/rafaelperoco/secretgenerator/blob/main/docs/AUDIT.md).

--- a/rust-crate/examples/quickstart.rs
+++ b/rust-crate/examples/quickstart.rs
@@ -1,0 +1,27 @@
+//! `cargo run --example quickstart`
+
+use secretgenerator::{PassphraseOptions, PasswordOptions, entropy, passphrase, password};
+
+fn main() -> Result<(), secretgenerator::Error> {
+    let pw = password(
+        PasswordOptions::default()
+            .length(24)
+            .charset("alphanum-symbols-v1")
+            .require_classes("lower,upper,digit,symbol"),
+    )?;
+    println!("password:    {} ({:.1} bits)", pw.password, pw.entropy_bits);
+
+    let phrase = passphrase(PassphraseOptions::default().words(8).separator("-"))?;
+    println!("passphrase:  {}", phrase.password);
+
+    let report = entropy("Tr0ub4dor&3")?;
+    println!("Tr0ub4dor&3: {:.1} bits", report.entropy_bits);
+    if let Some(ns) = report
+        .crack_time_estimates
+        .iter()
+        .find(|e| e.profile_id == "nation-state-v1")
+    {
+        println!("crack:       {} (nation-state)", ns.human_readable);
+    }
+    Ok(())
+}

--- a/rust-crate/src/lib.rs
+++ b/rust-crate/src/lib.rs
@@ -1,0 +1,606 @@
+//! Rust bindings for the auditable
+//! [`secretgenerator`](https://github.com/rafaelperoco/secretgenerator)
+//! CLI.
+//!
+//! Each function in this crate corresponds to a CLI subcommand. The
+//! function shells out to `secretgenerator`, parses the schema-v1 JSON
+//! envelope, and returns a typed [`Output`]. When the CLI exits
+//! non-zero a [`Error::Cli`] is returned with the structured error
+//! envelope attached so callers can branch on stable error codes
+//! (`E_ENTROPY_TOO_LOW`, `E_CHARSET_EMPTY`, `E_CLASS_IMPOSSIBLE`, etc.)
+//! rather than parsing free-form messages.
+//!
+//! # Install the binary
+//!
+//! ```sh
+//! npm install -g @secretgenerator/cli
+//! # or: brew install rafaelperoco/tap/secretgenerator
+//! # or: go install github.com/rafaelperoco/secretgenerator/cmd/secretgenerator@latest
+//! ```
+//!
+//! # Quick start
+//!
+//! ```no_run
+//! use secretgenerator::{password, PasswordOptions};
+//!
+//! let out = password(
+//!     PasswordOptions::default()
+//!         .length(24)
+//!         .charset("alphanum-symbols-v1")
+//!         .require_classes("lower,upper,digit,symbol"),
+//! )?;
+//! println!("{} ({} bits)", out.password, out.entropy_bits);
+//! # Ok::<_, secretgenerator::Error>(())
+//! ```
+
+#![forbid(unsafe_code)]
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+use thiserror::Error;
+
+/// The schema version this crate is pinned to.
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// Schema-v1 envelope returned by every generation subcommand.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Output {
+    pub schema_version: i64,
+    pub password: String,
+    pub length: i64,
+    pub charset_id: String,
+    pub charset_size: i64,
+    pub entropy_bits: f64,
+    pub algorithm: String,
+    pub subcommand: String,
+    pub version: String,
+    pub commit: String,
+    pub build_date: String,
+    pub request_id: String,
+    pub timestamp_utc: String,
+    #[serde(default)]
+    pub crack_time_estimates: Vec<CrackTimeEstimate>,
+}
+
+/// One attacker scenario applied to a credential's entropy.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CrackTimeEstimate {
+    pub profile_id: String,
+    pub description: String,
+    pub seconds: f64,
+    pub human_readable: String,
+}
+
+/// Structured error envelope emitted by the CLI when a subcommand
+/// fails. The `code` field is the part of the contract you are meant
+/// to branch on.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ErrorEnvelope {
+    pub error: ErrorDetail,
+    #[serde(default)]
+    pub request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ErrorDetail {
+    pub code: String,
+    pub message: String,
+    #[serde(default)]
+    pub hint: Option<String>,
+}
+
+/// Detailed CLI failure payload, boxed in [`Error::Cli`] so the
+/// enum stays small.
+#[derive(Debug)]
+pub struct CliFailure {
+    pub code: i32,
+    pub message: String,
+    pub envelope: Option<ErrorEnvelope>,
+}
+
+/// Error type returned by every function in this crate.
+#[derive(Error, Debug)]
+pub enum Error {
+    #[error("`secretgenerator` not on PATH: install via brew/npm/go")]
+    BinaryNotFound,
+    #[error("io error spawning secretgenerator: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("could not parse JSON from CLI: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("secretgenerator exited {}: {}", .0.code, .0.message)]
+    Cli(Box<CliFailure>),
+}
+
+impl Error {
+    /// Stable error code from the envelope (e.g. `E_ENTROPY_TOO_LOW`).
+    /// `None` when the failure was not a structured CLI error.
+    pub fn cli_code(&self) -> Option<&str> {
+        match self {
+            Error::Cli(f) => f.envelope.as_ref().map(|e| e.error.code.as_str()),
+            _ => None,
+        }
+    }
+}
+
+fn run(args: &[String], stdin: Option<&str>) -> Result<Output, Error> {
+    let mut cmd = Command::new("secretgenerator");
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if stdin.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Error::BinaryNotFound
+        } else {
+            Error::Io(e)
+        }
+    })?;
+    if let (Some(input), Some(mut sink)) = (stdin, child.stdin.take()) {
+        sink.write_all(input.as_bytes())?;
+    }
+    let out = child.wait_with_output()?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+        let envelope = serde_json::from_str::<ErrorEnvelope>(&stderr)
+            .or_else(|_| serde_json::from_str::<ErrorEnvelope>(&stdout))
+            .ok();
+        return Err(Error::Cli(Box::new(CliFailure {
+            code: out.status.code().unwrap_or(-1),
+            message: if !stderr.is_empty() { stderr } else { stdout },
+            envelope,
+        })));
+    }
+    Ok(serde_json::from_slice(&out.stdout)?)
+}
+
+fn run_estimates(args: &[String], stdin: Option<&str>) -> Result<EstimateOutput, Error> {
+    // entropy is the only subcommand that returns an envelope without
+    // a populated `password`/`length`/etc. — we deserialize into a
+    // partial struct.
+    let mut cmd = Command::new("secretgenerator");
+    cmd.args(args).stdout(Stdio::piped()).stderr(Stdio::piped());
+    if stdin.is_some() {
+        cmd.stdin(Stdio::piped());
+    }
+    let mut child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            Error::BinaryNotFound
+        } else {
+            Error::Io(e)
+        }
+    })?;
+    if let (Some(input), Some(mut sink)) = (stdin, child.stdin.take()) {
+        sink.write_all(input.as_bytes())?;
+    }
+    let out = child.wait_with_output()?;
+    if !out.status.success() {
+        let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+        return Err(Error::Cli(Box::new(CliFailure {
+            code: out.status.code().unwrap_or(-1),
+            message: stderr,
+            envelope: None,
+        })));
+    }
+    Ok(serde_json::from_slice(&out.stdout)?)
+}
+
+/// Schema-v1 envelope for the `entropy` subcommand. The CLI does not
+/// echo the password it analyzes, so [`Output`] would not deserialize
+/// cleanly — this struct keeps just the fields the subcommand
+/// populates.
+#[derive(Debug, Clone, Deserialize)]
+pub struct EstimateOutput {
+    pub schema_version: i64,
+    pub entropy_bits: f64,
+    #[serde(default)]
+    pub crack_time_estimates: Vec<CrackTimeEstimate>,
+    pub request_id: String,
+}
+
+fn common_args(
+    require_schema: Option<i64>,
+    show_crack_time: bool,
+    audit_log: Option<&str>,
+) -> Vec<String> {
+    let mut a = vec!["--json".to_string()];
+    if let Some(v) = require_schema {
+        a.push(format!("--require-schema-version={v}"));
+    }
+    if show_crack_time {
+        a.push("--show-crack-time".to_string());
+    }
+    if let Some(p) = audit_log {
+        a.push("--audit-log".to_string());
+        a.push(p.to_string());
+    }
+    a
+}
+
+// ----- password ------------------------------------------------------
+
+/// Builder for [`password`].
+#[derive(Debug, Clone)]
+pub struct PasswordOptions {
+    length: u32,
+    charset: String,
+    require_classes: Option<String>,
+    exclude: Option<String>,
+    min_entropy_bits: Option<f64>,
+    allow_weak: bool,
+    show_crack_time: bool,
+    audit_log: Option<String>,
+    require_schema_version: Option<i64>,
+}
+
+impl Default for PasswordOptions {
+    fn default() -> Self {
+        Self {
+            length: 20,
+            charset: "alphanum-v1".to_string(),
+            require_classes: None,
+            exclude: None,
+            min_entropy_bits: None,
+            allow_weak: false,
+            show_crack_time: true,
+            audit_log: None,
+            require_schema_version: Some(SCHEMA_VERSION),
+        }
+    }
+}
+
+impl PasswordOptions {
+    pub fn length(mut self, n: u32) -> Self {
+        self.length = n;
+        self
+    }
+    pub fn charset(mut self, c: impl Into<String>) -> Self {
+        self.charset = c.into();
+        self
+    }
+    pub fn require_classes(mut self, c: impl Into<String>) -> Self {
+        self.require_classes = Some(c.into());
+        self
+    }
+    pub fn exclude(mut self, e: impl Into<String>) -> Self {
+        self.exclude = Some(e.into());
+        self
+    }
+    pub fn min_entropy_bits(mut self, b: f64) -> Self {
+        self.min_entropy_bits = Some(b);
+        self
+    }
+    pub fn allow_weak(mut self, a: bool) -> Self {
+        self.allow_weak = a;
+        self
+    }
+    pub fn show_crack_time(mut self, s: bool) -> Self {
+        self.show_crack_time = s;
+        self
+    }
+    pub fn audit_log(mut self, p: impl Into<String>) -> Self {
+        self.audit_log = Some(p.into());
+        self
+    }
+}
+
+/// Generate a random password.
+pub fn password(opts: PasswordOptions) -> Result<Output, Error> {
+    let mut args = common_args(
+        opts.require_schema_version,
+        opts.show_crack_time,
+        opts.audit_log.as_deref(),
+    );
+    args.insert(0, "password".to_string());
+    args.push("--length".to_string());
+    args.push(opts.length.to_string());
+    args.push("--charset".to_string());
+    args.push(opts.charset);
+    if let Some(c) = opts.require_classes {
+        args.push("--require-classes".to_string());
+        args.push(c);
+    }
+    if let Some(e) = opts.exclude {
+        args.push("--exclude".to_string());
+        args.push(e);
+    }
+    if let Some(b) = opts.min_entropy_bits {
+        args.push("--min-entropy-bits".to_string());
+        args.push(b.to_string());
+    }
+    if opts.allow_weak {
+        args.push("--allow-weak".to_string());
+    }
+    run(&args, None)
+}
+
+// ----- passphrase ----------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct PassphraseOptions {
+    words: u32,
+    separator: String,
+    capitalize: bool,
+    digit_suffix: bool,
+    min_entropy_bits: Option<f64>,
+    allow_weak: bool,
+    show_crack_time: bool,
+    audit_log: Option<String>,
+    require_schema_version: Option<i64>,
+}
+
+impl Default for PassphraseOptions {
+    fn default() -> Self {
+        Self {
+            words: 8,
+            separator: "-".to_string(),
+            capitalize: false,
+            digit_suffix: false,
+            min_entropy_bits: None,
+            allow_weak: false,
+            show_crack_time: true,
+            audit_log: None,
+            require_schema_version: Some(SCHEMA_VERSION),
+        }
+    }
+}
+
+impl PassphraseOptions {
+    pub fn words(mut self, n: u32) -> Self {
+        self.words = n;
+        self
+    }
+    pub fn separator(mut self, s: impl Into<String>) -> Self {
+        self.separator = s.into();
+        self
+    }
+    pub fn capitalize(mut self, c: bool) -> Self {
+        self.capitalize = c;
+        self
+    }
+    pub fn digit_suffix(mut self, d: bool) -> Self {
+        self.digit_suffix = d;
+        self
+    }
+    pub fn min_entropy_bits(mut self, b: f64) -> Self {
+        self.min_entropy_bits = Some(b);
+        self
+    }
+    pub fn allow_weak(mut self, a: bool) -> Self {
+        self.allow_weak = a;
+        self
+    }
+    pub fn show_crack_time(mut self, s: bool) -> Self {
+        self.show_crack_time = s;
+        self
+    }
+}
+
+pub fn passphrase(opts: PassphraseOptions) -> Result<Output, Error> {
+    let mut args = common_args(
+        opts.require_schema_version,
+        opts.show_crack_time,
+        opts.audit_log.as_deref(),
+    );
+    args.insert(0, "passphrase".to_string());
+    args.push("--words".to_string());
+    args.push(opts.words.to_string());
+    args.push("--separator".to_string());
+    args.push(opts.separator);
+    if opts.capitalize {
+        args.push("--capitalize".to_string());
+    }
+    if opts.digit_suffix {
+        args.push("--digit-suffix".to_string());
+    }
+    if let Some(b) = opts.min_entropy_bits {
+        args.push("--min-entropy-bits".to_string());
+        args.push(b.to_string());
+    }
+    if opts.allow_weak {
+        args.push("--allow-weak".to_string());
+    }
+    run(&args, None)
+}
+
+// ----- secret --------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct SecretOptions {
+    bytes: u32,
+    prefix: Option<String>,
+    min_entropy_bits: Option<f64>,
+    allow_weak: bool,
+    show_crack_time: bool,
+    audit_log: Option<String>,
+    require_schema_version: Option<i64>,
+}
+
+impl Default for SecretOptions {
+    fn default() -> Self {
+        Self {
+            bytes: 32,
+            prefix: None,
+            min_entropy_bits: None,
+            allow_weak: false,
+            show_crack_time: true,
+            audit_log: None,
+            require_schema_version: Some(SCHEMA_VERSION),
+        }
+    }
+}
+
+impl SecretOptions {
+    pub fn bytes(mut self, n: u32) -> Self {
+        self.bytes = n;
+        self
+    }
+    pub fn prefix(mut self, p: impl Into<String>) -> Self {
+        self.prefix = Some(p.into());
+        self
+    }
+}
+
+pub fn secret(opts: SecretOptions) -> Result<Output, Error> {
+    let mut args = common_args(
+        opts.require_schema_version,
+        opts.show_crack_time,
+        opts.audit_log.as_deref(),
+    );
+    args.insert(0, "secret".to_string());
+    args.push("--bytes".to_string());
+    args.push(opts.bytes.to_string());
+    if let Some(p) = opts.prefix {
+        args.push("--prefix".to_string());
+        args.push(p);
+    }
+    if let Some(b) = opts.min_entropy_bits {
+        args.push("--min-entropy-bits".to_string());
+        args.push(b.to_string());
+    }
+    if opts.allow_weak {
+        args.push("--allow-weak".to_string());
+    }
+    run(&args, None)
+}
+
+// ----- api-key -------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct ApiKeyOptions {
+    length: u32,
+    prefix: String,
+    separator: String,
+    min_entropy_bits: Option<f64>,
+    allow_weak: bool,
+    show_crack_time: bool,
+    audit_log: Option<String>,
+    require_schema_version: Option<i64>,
+}
+
+impl Default for ApiKeyOptions {
+    fn default() -> Self {
+        Self {
+            length: 32,
+            prefix: "sk".to_string(),
+            separator: "_".to_string(),
+            min_entropy_bits: None,
+            allow_weak: false,
+            show_crack_time: true,
+            audit_log: None,
+            require_schema_version: Some(SCHEMA_VERSION),
+        }
+    }
+}
+
+impl ApiKeyOptions {
+    pub fn length(mut self, n: u32) -> Self {
+        self.length = n;
+        self
+    }
+    pub fn prefix(mut self, p: impl Into<String>) -> Self {
+        self.prefix = p.into();
+        self
+    }
+    pub fn separator(mut self, s: impl Into<String>) -> Self {
+        self.separator = s.into();
+        self
+    }
+}
+
+pub fn api_key(opts: ApiKeyOptions) -> Result<Output, Error> {
+    let mut args = common_args(
+        opts.require_schema_version,
+        opts.show_crack_time,
+        opts.audit_log.as_deref(),
+    );
+    args.insert(0, "api-key".to_string());
+    args.push("--length".to_string());
+    args.push(opts.length.to_string());
+    args.push("--prefix".to_string());
+    args.push(opts.prefix);
+    args.push("--separator".to_string());
+    args.push(opts.separator);
+    if let Some(b) = opts.min_entropy_bits {
+        args.push("--min-entropy-bits".to_string());
+        args.push(b.to_string());
+    }
+    if opts.allow_weak {
+        args.push("--allow-weak".to_string());
+    }
+    run(&args, None)
+}
+
+// ----- pin -----------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct PinOptions {
+    digits: u32,
+    acknowledge_low_entropy: bool,
+    allow_weak_pattern: bool,
+    show_crack_time: bool,
+    audit_log: Option<String>,
+    require_schema_version: Option<i64>,
+}
+
+impl Default for PinOptions {
+    fn default() -> Self {
+        Self {
+            digits: 6,
+            acknowledge_low_entropy: true,
+            allow_weak_pattern: false,
+            show_crack_time: false,
+            audit_log: None,
+            require_schema_version: Some(SCHEMA_VERSION),
+        }
+    }
+}
+
+impl PinOptions {
+    pub fn digits(mut self, n: u32) -> Self {
+        self.digits = n;
+        self
+    }
+    pub fn acknowledge_low_entropy(mut self, a: bool) -> Self {
+        self.acknowledge_low_entropy = a;
+        self
+    }
+    pub fn allow_weak_pattern(mut self, a: bool) -> Self {
+        self.allow_weak_pattern = a;
+        self
+    }
+}
+
+pub fn pin(opts: PinOptions) -> Result<Output, Error> {
+    let mut args = common_args(
+        opts.require_schema_version,
+        opts.show_crack_time,
+        opts.audit_log.as_deref(),
+    );
+    args.insert(0, "pin".to_string());
+    args.push("--digits".to_string());
+    args.push(opts.digits.to_string());
+    if opts.acknowledge_low_entropy {
+        args.push("--acknowledge-low-entropy".to_string());
+    }
+    if opts.allow_weak_pattern {
+        args.push("--allow-weak-pattern".to_string());
+    }
+    run(&args, None)
+}
+
+// ----- entropy -------------------------------------------------------
+
+/// Estimate the entropy and crack time of an existing string. The
+/// candidate is piped on stdin so it never appears in argv.
+pub fn entropy(candidate: &str) -> Result<EstimateOutput, Error> {
+    let args = vec![
+        "entropy".to_string(),
+        "--json".to_string(),
+        format!("--require-schema-version={SCHEMA_VERSION}"),
+        "--show-crack-time".to_string(),
+    ];
+    run_estimates(&args, Some(candidate))
+}


### PR DESCRIPTION
Closes part of #13.

Adds two language wrappers around the CLI so the obvious-search install path works in Python and Rust ecosystems:

- **`pip install secretgenerator`** — pure-Python wrapper at `python/`. `secretgenerator.password()`, `.passphrase()`, `.secret()`, `.api_key()`, `.pin()`, `.entropy()` return parsed schema-v1 dicts. `SecretgeneratorError.code` exposes the stable error code (`E_ENTROPY_TOO_LOW`, etc.) so callers branch on identifiers rather than message strings.
- **`cargo add secretgenerator`** — typed Rust crate at `rust-crate/`. Builder-pattern options structs (`PasswordOptions::default().length(24).charset("alphanum-symbols-v1")`), `Output` and `CrackTimeEstimate` derive serde, `Error::cli_code()` exposes the stable code.

Why wrappers, not reimplementations: cryptographic primitives stay in the audited binary with SLSA L3 + cosign keyless. The wrappers just parse JSON.

Both ship CI workflows that:
- Install the latest CLI via the composite action (`setup-secretgenerator`)
- Build + test on ubuntu/macos/windows
- For Rust: `cargo fmt --check` and `cargo clippy -D warnings`

10 pytest cases cover schema pinning, error codes, required-classes guarantee, etc. — all green locally. `cargo run --example quickstart` produces the expected output.