### PR TITLE
feat: per-subcommand pages on the website

### DIFF
--- a/web/scripts/build-llms-txt.mjs
+++ b/web/scripts/build-llms-txt.mjs
@@ -160,7 +160,9 @@ Current release: ${VERSION}. Site: ${SITE}. Source: ${REPO}.
 
 ${SUBCOMMANDS.map(
   (s) =>
-    `- [${s}](${SITE}/#install): \`secretgenerator ${s} --json\` — see ${REPO}/blob/main/docs/SUBCOMMANDS.md#${s}`
+    s === "entropy"
+      ? `- [${s}](${REPO}/blob/main/docs/SUBCOMMANDS.md#${s}): \`secretgenerator ${s} --json\` — assess existing credentials (CLI only)`
+      : `- [${s}](${SITE}/${s}/): \`secretgenerator ${s} --json\` — dedicated page with live generator, defaults, snippets, and FAQ`
 ).join("\n")}
 
 ## Output schema

--- a/web/src/components/Generator.tsx
+++ b/web/src/components/Generator.tsx
@@ -62,8 +62,13 @@ const SUBCOMMAND_HINT: Record<Subcommand, string> = {
   pin: "6 digits, ~20 bits — PINs are intrinsically weak; safe only with rate-limited verifiers",
 };
 
-export default function Generator() {
-  const [active, setActive] = useState<Subcommand>("password");
+export type GeneratorProps = {
+  /** Subcommand selected when the component mounts. Defaults to "password". */
+  initial?: Subcommand;
+};
+
+export default function Generator({ initial = "password" }: GeneratorProps) {
+  const [active, setActive] = useState<Subcommand>(initial);
   const [state, setState] = useState<State>({ kind: "loading" });
   const [copied, setCopied] = useState<"password" | "json" | null>(null);
   const [profiles, setProfiles] = useState<AttackerProfile[]>([]);

--- a/web/src/data/subcommands.ts
+++ b/web/src/data/subcommands.ts
@@ -1,0 +1,408 @@
+// Catalog of per-subcommand pages. Each entry drives one route under
+// /<slug>/ and feeds the SEO metadata, intro copy, and snippet block.
+// Keep this file the single source of truth — index.astro and the
+// per-page layouts both read from here.
+
+export type SubcommandSlug =
+  | "password"
+  | "passphrase"
+  | "secret"
+  | "api-key"
+  | "pin";
+
+export type SnippetExample = {
+  language: string;
+  filename: string;
+  code: string;
+};
+
+export type SubcommandPage = {
+  slug: SubcommandSlug;
+  /** Subcommand id passed to the WASM Generator (matches CLI argv). */
+  generatorId: SubcommandSlug;
+  title: string;
+  metaDescription: string;
+  h1: string;
+  intro: string;
+  defaults: { name: string; value: string }[];
+  cliExamples: { label: string; cmd: string }[];
+  snippets: SnippetExample[];
+  faq: { q: string; a: string }[];
+};
+
+const SCHEMA_PIN = "--require-schema-version=1";
+
+const PYTHON_SNIPPET = (subcommand: SubcommandSlug, args: string) => `import secretgenerator_py as sg
+
+result = sg.${subcommand.replace("-", "_")}(${args})
+print(result["password"], "—", result["entropy_bits"], "bits")`;
+
+const NODE_SNIPPET = (subcommand: SubcommandSlug, args: string[]) => `import { execFileSync } from "node:child_process";
+
+const json = execFileSync("secretgenerator", [
+  "${subcommand}", "--json", "${SCHEMA_PIN}",
+  ${args.map((a) => JSON.stringify(a)).join(", ")}
+], { encoding: "utf8" });
+const out = JSON.parse(json);
+console.log(out.password, "—", out.entropy_bits, "bits");`;
+
+const RUST_SNIPPET = (
+  subcommand: string,
+  builder: string,
+) => `use secretgenerator::{${subcommand}, ${capitalize(subcommand)}Options};
+
+let r = ${subcommand}(${builder})?;
+println!("{} ({:.1} bits)", r.password, r.entropy_bits);
+# Ok::<_, secretgenerator::Error>(())`;
+
+function capitalize(s: string): string {
+  // password -> Password, api_key -> ApiKey
+  return s
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join("");
+}
+
+const GO_SNIPPET = (call: string) => `package main
+
+import (
+\t"fmt"
+\t"github.com/rafaelperoco/secretgenerator/pkg/secretgen"
+)
+
+func main() {
+\tres, err := ${call}
+\tif err != nil { panic(err) }
+\tfmt.Printf("%s (%.1f bits)\\n", res.Password, res.EntropyBits)
+}`;
+
+export const SUBCOMMANDS: SubcommandPage[] = [
+  {
+    slug: "password",
+    generatorId: "password",
+    title: "Random password generator (auditable, NIST-aligned) — secretgenerator",
+    metaDescription:
+      "Cryptographically secure password generator backed by the OS CSPRNG. Schema-v1 JSON output, NIST 800-63B-4 entropy floors, class guarantees, SLSA L3.",
+    h1: "Auditable random password generator",
+    intro:
+      "Uses the OS CSPRNG with rejection sampling, no modulo bias. Default 20 characters at ~119 bits — well above the NIST SP 800-63B-4 floor. Class requirements (lower, upper, digit, symbol) are guaranteed, not nudged.",
+    defaults: [
+      { name: "length", value: "20" },
+      { name: "charset", value: "alphanum-v1" },
+      { name: "min entropy", value: "80 bits (NIST floor)" },
+      { name: "algorithm", value: "crypto/rand + rejection sampling" },
+    ],
+    cliExamples: [
+      {
+        label: "Default 20-char alphanumeric",
+        cmd: "secretgenerator password --json --show-crack-time",
+      },
+      {
+        label: "24-char with all classes guaranteed",
+        cmd: "secretgenerator password --length 24 --charset alphanum-symbols-v1 --require-classes lower,upper,digit,symbol --json",
+      },
+      {
+        label: "Pin schema for safe parsing",
+        cmd: `secretgenerator password ${SCHEMA_PIN} --json`,
+      },
+    ],
+    snippets: [
+      {
+        language: "Python",
+        filename: "generate_password.py",
+        code: PYTHON_SNIPPET(
+          "password",
+          'length=24, charset="alphanum-symbols-v1", require_classes="lower,upper,digit,symbol"',
+        ),
+      },
+      {
+        language: "Node.js",
+        filename: "generate-password.mjs",
+        code: NODE_SNIPPET("password", [
+          "--length",
+          "24",
+          "--charset",
+          "alphanum-symbols-v1",
+          "--require-classes",
+          "lower,upper,digit,symbol",
+        ]),
+      },
+      {
+        language: "Rust",
+        filename: "main.rs",
+        code: RUST_SNIPPET(
+          "password",
+          'PasswordOptions::default().length(24).charset("alphanum-symbols-v1").require_classes("lower,upper,digit,symbol")',
+        ),
+      },
+      {
+        language: "Go",
+        filename: "main.go",
+        code: GO_SNIPPET(
+          'secretgen.Password(secretgen.PasswordOptions{\n\t\tLength: 24,\n\t\tCharsetID: "alphanum-symbols-v1",\n\t\tRequiredClasses: "lower,upper,digit,symbol",\n\t})',
+        ),
+      },
+    ],
+    faq: [
+      {
+        q: "Is this safer than letting Claude or ChatGPT generate the password?",
+        a: "Yes. Recent studies show LLMs produce passwords with ~20 bits of effective entropy regardless of what they claim — they cannot uniformly sample. secretgenerator delegates to the OS CSPRNG so every output is uniform across the chosen charset.",
+      },
+      {
+        q: "Why does the JSON output omit the password by default in some commands?",
+        a: "It does not for password — the password field is part of schema v1. The entropy subcommand omits it because the caller already has the candidate. See docs/SCHEMA.md.",
+      },
+      {
+        q: "Can I disable the entropy floor?",
+        a: "Pass --allow-weak. The output will carry a warning entry that propagates to the audit log so the deviation is recorded.",
+      },
+    ],
+  },
+  {
+    slug: "passphrase",
+    generatorId: "passphrase",
+    title: "Diceware passphrase generator (EFF Large Wordlist) — secretgenerator",
+    metaDescription:
+      "Generate auditable diceware passphrases from the EFF Large Wordlist. SHA-256 verified at startup. Schema-v1 JSON output, ~103 bits at 8 words.",
+    h1: "Diceware passphrase generator",
+    intro:
+      "Words sampled uniformly from the EFF Large Wordlist (7,776 entries, ~12.92 bits per word) with the wordlist hash verified at process start. Eight words gives ~103 bits — strong against everything short of a nation-state, memorable enough for humans.",
+    defaults: [
+      { name: "words", value: "8" },
+      { name: "separator", value: "-" },
+      { name: "wordlist", value: "EFF Large (7,776 words)" },
+      { name: "min entropy", value: "80 bits (Reinhold/EFF floor)" },
+    ],
+    cliExamples: [
+      {
+        label: "Default 8-word, dash-separated",
+        cmd: "secretgenerator passphrase --json --show-crack-time",
+      },
+      {
+        label: "10 words, space separator",
+        cmd: 'secretgenerator passphrase --words 10 --separator " " --json',
+      },
+      {
+        label: "Compatibility flags for legacy verifiers",
+        cmd: "secretgenerator passphrase --capitalize --digit-suffix --json",
+      },
+    ],
+    snippets: [
+      {
+        language: "Python",
+        filename: "generate_passphrase.py",
+        code: PYTHON_SNIPPET("passphrase", 'words=10, separator="-"'),
+      },
+      {
+        language: "Node.js",
+        filename: "generate-passphrase.mjs",
+        code: NODE_SNIPPET("passphrase", ["--words", "10", "--separator", "-"]),
+      },
+      {
+        language: "Rust",
+        filename: "main.rs",
+        code: RUST_SNIPPET(
+          "passphrase",
+          'PassphraseOptions::default().words(10).separator("-")',
+        ),
+      },
+    ],
+    faq: [
+      {
+        q: "Why diceware instead of just a long random password?",
+        a: "Memorability without sacrificing entropy. Six diceware words (~77.5 bits) is roughly equivalent in strength to a 13-character random alphanumeric, but a human can actually retain it.",
+      },
+      {
+        q: "How is the wordlist's integrity verified?",
+        a: "The binary embeds the EFF Large Wordlist with a SHA-256 hash that is verified at process start. If the embedded copy ever drifts from the published EFF list, generation refuses to start.",
+      },
+    ],
+  },
+  {
+    slug: "secret",
+    generatorId: "secret",
+    title:
+      "CSPRNG secret generator (base64url, 256-bit) — secretgenerator",
+    metaDescription:
+      "Generate raw CSPRNG bytes encoded as URL-safe base64. Designed for machine-to-machine API tokens, JWT secrets, encryption keys. Schema-v1, SLSA L3.",
+    h1: "Machine-to-machine secret generator",
+    intro:
+      "Raw bytes from the OS CSPRNG, encoded as URL-safe base64 without padding. Default 32 bytes (256 bits) — the right shape for JWT signing keys, opaque API tokens, session IDs, and seed material. No charset to argue about, just bytes.",
+    defaults: [
+      { name: "bytes", value: "32 (256 bits)" },
+      { name: "encoding", value: "URL-safe base64, no padding" },
+      { name: "min entropy", value: "128 bits (NIST 800-131A target)" },
+      { name: "algorithm", value: "crypto/rand + base64url" },
+    ],
+    cliExamples: [
+      {
+        label: "Default 32 bytes",
+        cmd: "secretgenerator secret --json",
+      },
+      {
+        label: "Prefixed for environment variables",
+        cmd: 'secretgenerator secret --prefix "JWT_" --json',
+      },
+      {
+        label: "64 bytes for HMAC-SHA-512 keys",
+        cmd: "secretgenerator secret --bytes 64 --json",
+      },
+    ],
+    snippets: [
+      {
+        language: "Python",
+        filename: "generate_secret.py",
+        code: PYTHON_SNIPPET("secret", "bytes_=32"),
+      },
+      {
+        language: "Node.js",
+        filename: "generate-secret.mjs",
+        code: NODE_SNIPPET("secret", ["--bytes", "32"]),
+      },
+      {
+        language: "Rust",
+        filename: "main.rs",
+        code: RUST_SNIPPET("secret", "SecretOptions::default().bytes(32)"),
+      },
+    ],
+    faq: [
+      {
+        q: "Why base64url and not hex?",
+        a: "Same entropy in fewer characters (43 vs 64 for 32 bytes), URL-safe, and matches the encoding used by JWT, OAuth, and most modern APIs. If you need hex, pipe through xxd or shasum.",
+      },
+      {
+        q: "Is 32 bytes enough?",
+        a: "Yes for almost everything. NIST SP 800-131A targets 128 bits of strength; 32 bytes (256 bits) gives a 2× safety margin. Use 64 bytes for HMAC-SHA-512 keys where the hash output size dictates the recommended key length.",
+      },
+    ],
+  },
+  {
+    slug: "api-key",
+    generatorId: "api-key",
+    title: "API key generator (Stripe-style prefix_random) — secretgenerator",
+    metaDescription:
+      "Generate Stripe-style API keys with a configurable prefix and base62 secret body. Schema-v1 JSON, audit log, NIST-aligned entropy.",
+    h1: "Stripe-style API key generator",
+    intro:
+      "Tokens in the prefix_random shape that Stripe popularized: a static identifier ('sk_live', 'ghp', 'xoxb') makes leaked tokens trivially classifiable in repo scans, plus a base62 random body sized for ≥128 bits. Default 32 characters of base62 = ~190 bits.",
+    defaults: [
+      { name: "prefix", value: "sk" },
+      { name: "separator", value: "_" },
+      { name: "body length", value: "32 chars (~190 bits)" },
+      { name: "min entropy", value: "128 bits" },
+    ],
+    cliExamples: [
+      {
+        label: "Default sk_*",
+        cmd: "secretgenerator api-key --json",
+      },
+      {
+        label: "Stripe live secret key",
+        cmd: 'secretgenerator api-key --prefix "sk_live" --length 40 --json',
+      },
+      {
+        label: "GitHub-style PAT",
+        cmd: 'secretgenerator api-key --prefix "ghp" --separator "_" --length 36 --json',
+      },
+    ],
+    snippets: [
+      {
+        language: "Python",
+        filename: "generate_api_key.py",
+        code: PYTHON_SNIPPET("api-key", 'prefix="sk_live", length=40'),
+      },
+      {
+        language: "Node.js",
+        filename: "generate-api-key.mjs",
+        code: NODE_SNIPPET("api-key", [
+          "--prefix",
+          "sk_live",
+          "--length",
+          "40",
+        ]),
+      },
+      {
+        language: "Rust",
+        filename: "main.rs",
+        code: RUST_SNIPPET(
+          "api_key",
+          'ApiKeyOptions::default().prefix("sk_live").length(40)',
+        ),
+      },
+    ],
+    faq: [
+      {
+        q: "Why does the prefix matter for security?",
+        a: "GitHub's secret scanning, Trufflehog, gitleaks, and similar tools recognize known prefixes. A leaked token with a recognizable prefix gets revoked within minutes by upstream platforms; an opaque random string can sit in a public repo for months.",
+      },
+      {
+        q: "Should the prefix be counted toward entropy?",
+        a: "No. The prefix is a public identifier; only the base62 body contributes entropy. Set --length to size the secret body alone.",
+      },
+    ],
+  },
+  {
+    slug: "pin",
+    generatorId: "pin",
+    title: "Numeric PIN generator with weak-pattern blocklist — secretgenerator",
+    metaDescription:
+      "Cryptographically secure numeric PIN generator that rejects all-same-digit, sequences, top-20 weak PINs, and calendar years. Audit log, schema-v1.",
+    h1: "Auditable numeric PIN generator",
+    intro:
+      "PINs are intrinsically low-entropy (a 4-digit PIN carries only ~13 bits) so the subcommand requires --acknowledge-low-entropy. Output is rejected when it matches all-same-digit, strict sequences, the DataGenetics-2012 top-20 most-common PINs, calendar years, or short repetitions. Use only with rate-limited verifiers.",
+    defaults: [
+      { name: "digits", value: "6 (~19.9 bits)" },
+      { name: "blocklist", value: "Top-20 + sequences + years" },
+      { name: "acknowledgement", value: "Required" },
+    ],
+    cliExamples: [
+      {
+        label: "Default 6 digits",
+        cmd: "secretgenerator pin --acknowledge-low-entropy --json",
+      },
+      {
+        label: "8 digits with crack time",
+        cmd: "secretgenerator pin --digits 8 --acknowledge-low-entropy --show-crack-time --json",
+      },
+      {
+        label: "Disable blocklist (NOT RECOMMENDED)",
+        cmd: "secretgenerator pin --acknowledge-low-entropy --allow-weak-pattern --json",
+      },
+    ],
+    snippets: [
+      {
+        language: "Python",
+        filename: "generate_pin.py",
+        code: PYTHON_SNIPPET("pin", "digits=6"),
+      },
+      {
+        language: "Node.js",
+        filename: "generate-pin.mjs",
+        code: NODE_SNIPPET("pin", [
+          "--digits",
+          "6",
+          "--acknowledge-low-entropy",
+        ]),
+      },
+      {
+        language: "Rust",
+        filename: "main.rs",
+        code: RUST_SNIPPET("pin", "PinOptions::default().digits(6)"),
+      },
+    ],
+    faq: [
+      {
+        q: "Why require --acknowledge-low-entropy?",
+        a: "Forcing the caller to spell it out makes accidental misuse loud. PINs belong on rate-limited verifiers (banking apps, hardware tokens) — never as primary authenticators.",
+      },
+      {
+        q: "What's in the weak-pattern blocklist?",
+        a: "All-same-digit (1111), strict sequences (1234, 9876), short repetitions (1212, 123123), the DataGenetics 2012 top-20 most-common PINs, and four-digit calendar years from 1900–2099.",
+      },
+    ],
+  },
+];
+
+export function findSubcommand(slug: string): SubcommandPage | undefined {
+  return SUBCOMMANDS.find((s) => s.slug === slug);
+}

--- a/web/src/pages/[slug].astro
+++ b/web/src/pages/[slug].astro
@@ -1,0 +1,211 @@
+---
+import Base from "../layouts/Base.astro";
+import Generator from "../components/Generator.tsx";
+import { SUBCOMMANDS, type SubcommandPage } from "../data/subcommands";
+
+export function getStaticPaths() {
+  return SUBCOMMANDS.map((s) => ({ params: { slug: s.slug }, props: { entry: s } }));
+}
+
+interface Props {
+  entry: SubcommandPage;
+}
+
+const { entry } = Astro.props;
+const ghRepo = "https://github.com/rafaelperoco/secretgenerator";
+const version = "v2.0.0";
+const otherEntries = SUBCOMMANDS.filter((s) => s.slug !== entry.slug);
+---
+
+<Base
+  title={entry.title}
+  description={entry.metaDescription}
+  path={`/${entry.slug}/`}
+>
+  <header
+    class="border-b border-[var(--color-line)] sticky top-0 backdrop-blur bg-[color-mix(in_oklab,var(--color-bg),transparent_40%)] z-10"
+  >
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 h-12 flex items-center gap-3">
+      <a
+        href="/"
+        class="flex items-center gap-2 font-semibold tracking-tight text-sm sm:text-base"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          aria-hidden="true"
+          class="shrink-0"
+        >
+          <rect
+            x="0.5"
+            y="0.5"
+            width="13"
+            height="13"
+            rx="2"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1"
+          />
+          <rect x="3.5" y="3.5" width="7" height="7" fill="currentColor" />
+        </svg>
+        secretgenerator
+      </a>
+      <span class="font-mono text-[10px] sm:text-xs text-[var(--color-mute)]"
+        >{version}</span
+      >
+      <span class="ml-auto"></span>
+      <nav
+        class="hidden md:flex items-center gap-5 text-sm text-[var(--color-mute)]"
+      >
+        <a class="hover:text-[var(--color-fg)] transition" href="/">home</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="/password/">password</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="/passphrase/">passphrase</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="/secret/">secret</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="/api-key/">api key</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="/pin/">pin</a>
+        <a
+          class="hover:text-[var(--color-fg)] transition"
+          href={ghRepo}
+          target="_blank"
+          rel="noopener">↗ source</a
+        >
+      </nav>
+      <a
+        class="md:hidden text-xs text-[var(--color-mute)] hover:text-[var(--color-fg)] transition"
+        href={ghRepo}
+        target="_blank"
+        rel="noopener"
+        aria-label="GitHub repository">↗ github</a
+      >
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-4 sm:px-6 py-12 sm:py-16">
+    <p class="text-[10px] sm:text-xs font-mono text-[var(--color-mute)] mb-3">
+      <a class="hover:text-[var(--color-fg)] transition" href="/">home</a>
+      <span class="mx-1">/</span>
+      <span class="text-[var(--color-fg)]">{entry.slug}</span>
+    </p>
+
+    <header class="max-w-3xl mb-10 sm:mb-12">
+      <p class="text-[10px] sm:text-xs font-mono text-[var(--color-accent)] mb-2 uppercase tracking-wider">
+        secretgenerator · {entry.slug}
+      </p>
+      <h1 class="text-3xl sm:text-4xl md:text-5xl font-semibold tracking-tight leading-[1.05] mb-4">
+        {entry.h1}
+      </h1>
+      <p class="text-base sm:text-lg text-[var(--color-mute)]">{entry.intro}</p>
+    </header>
+
+    {/* Defaults table */}
+    <section class="mb-10 sm:mb-14">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">
+        defaults
+      </h2>
+      <div class="border border-[var(--color-line)] rounded-lg overflow-hidden bg-[var(--color-panel)]">
+        <table class="w-full text-sm font-mono">
+          <tbody>
+            {entry.defaults.map((d, i) => (
+              <tr class={i === entry.defaults.length - 1 ? "" : "border-b border-[var(--color-line)]"}>
+                <td class="px-4 py-2 text-[var(--color-mute)] w-1/3">{d.name}</td>
+                <td class="px-4 py-2">{d.value}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    {/* Live generator preselected */}
+    <section id="generate" class="mb-12 sm:mb-16 scroll-mt-16">
+      <div class="flex flex-col sm:flex-row sm:items-baseline sm:justify-between gap-1 sm:gap-2 mb-4">
+        <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)]">
+          generate
+        </h2>
+        <span class="text-[10px] font-mono text-[var(--color-mute)]">
+          runs in your browser · WebAssembly · same code as the CLI
+        </span>
+      </div>
+      <Generator client:only="react" initial={entry.generatorId} />
+    </section>
+
+    {/* CLI examples */}
+    <section class="mb-12 sm:mb-16">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">
+        cli
+      </h2>
+      <div class="grid gap-3">
+        {entry.cliExamples.map((ex) => (
+          <div class="border border-[var(--color-line)] rounded-lg p-4 bg-[var(--color-panel)] min-w-0">
+            <div class="text-xs font-mono text-[var(--color-mute)] mb-2">{ex.label}</div>
+            <pre class="font-mono text-[11px] sm:text-[12px] whitespace-pre-wrap break-all sm:break-normal sm:whitespace-pre sm:overflow-x-auto max-w-full">{ex.cmd}</pre>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    {/* Code snippets */}
+    <section class="mb-12 sm:mb-16">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">
+        snippets
+      </h2>
+      <div class="grid gap-3">
+        {entry.snippets.map((sn) => (
+          <div class="border border-[var(--color-line)] rounded-lg overflow-hidden bg-[var(--color-panel)] min-w-0">
+            <div class="flex items-center justify-between px-4 py-2 border-b border-[var(--color-line)]">
+              <span class="text-xs font-mono text-[var(--color-fg)]">{sn.language}</span>
+              <span class="text-[10px] font-mono text-[var(--color-mute)]">{sn.filename}</span>
+            </div>
+            <pre class="font-mono text-[11px] sm:text-[12px] whitespace-pre-wrap break-all sm:break-normal sm:whitespace-pre sm:overflow-x-auto px-4 py-3 max-w-full">{sn.code}</pre>
+          </div>
+        ))}
+      </div>
+    </section>
+
+    {/* FAQ */}
+    <section class="mb-12 sm:mb-16">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">
+        faq
+      </h2>
+      <div class="grid gap-4">
+        {entry.faq.map((f) => (
+          <details class="border border-[var(--color-line)] rounded-lg p-4 bg-[var(--color-panel)] group">
+            <summary class="cursor-pointer text-sm font-medium tracking-tight">
+              {f.q}
+            </summary>
+            <p class="text-sm text-[var(--color-mute)] mt-3 leading-relaxed">{f.a}</p>
+          </details>
+        ))}
+      </div>
+    </section>
+
+    {/* Cross-link to other subcommands */}
+    <section class="mb-8">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">
+        related
+      </h2>
+      <div class="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {otherEntries.map((o) => (
+          <a
+            href={`/${o.slug}/`}
+            class="border border-[var(--color-line)] rounded-md px-3 py-2 text-sm font-mono hover:border-[var(--color-fg)] hover:text-[var(--color-fg)] text-[var(--color-mute)] transition"
+          >
+            ↗ {o.slug}
+          </a>
+        ))}
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t border-[var(--color-line)] mt-16 sm:mt-24">
+    <div class="mx-auto max-w-6xl px-4 sm:px-6 py-6 sm:py-8 flex flex-wrap items-center gap-3 sm:gap-4 text-xs text-[var(--color-mute)]">
+      <span>generation runs in your shell. we never see your secrets.</span>
+      <span class="ml-auto"></span>
+      <a class="hover:text-[var(--color-fg)] transition" href={`${ghRepo}/blob/main/SECURITY.md`} target="_blank" rel="noopener">security</a>
+      <a class="hover:text-[var(--color-fg)] transition" href={`${ghRepo}/blob/main/docs/CRYPTO.md`} target="_blank" rel="noopener">crypto</a>
+      <a class="hover:text-[var(--color-fg)] transition" href={`${ghRepo}/blob/main/CHANGELOG.md`} target="_blank" rel="noopener">changelog</a>
+      <a class="hover:text-[var(--color-fg)] transition" href={ghRepo} target="_blank" rel="noopener">↗ github</a>
+    </div>
+  </footer>
+</Base>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Base from "../layouts/Base.astro";
 import Generator from "../components/Generator.tsx";
+import { SUBCOMMANDS } from "../data/subcommands";
 
 const version = "v2.0.0";
 const ghRepo = "https://github.com/rafaelperoco/secretgenerator";
@@ -23,7 +24,7 @@ const installCmd = `go install github.com/rafaelperoco/secretgenerator/cmd/secre
         <a class="hover:text-[var(--color-fg)] transition" href="#generate">generate</a>
         <a class="hover:text-[var(--color-fg)] transition" href="#why">why</a>
         <a class="hover:text-[var(--color-fg)] transition" href="#install">install</a>
-        <a class="hover:text-[var(--color-fg)] transition" href="#schema">schema</a>
+        <a class="hover:text-[var(--color-fg)] transition" href="#subcommands">subcommands</a>
         <a class="hover:text-[var(--color-fg)] transition" href="#verify">verify</a>
         <a class="hover:text-[var(--color-fg)] transition" href={ghRepo} target="_blank" rel="noopener">↗ source</a>
       </nav>
@@ -145,29 +146,40 @@ docker run --rm ghcr.io/rafaelperoco/secretgenerator:{version} --json</pre>
       </p>
     </section>
 
-    {/* Schema */}
-    <section id="schema" class="mt-16 sm:mt-24">
-      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">schema</h2>
+    {/* Subcommands directory */}
+    <section id="subcommands" class="mt-16 sm:mt-24">
+      <h2 class="text-xs font-mono uppercase tracking-wider text-[var(--color-mute)] mb-3">subcommands</h2>
       <h3 class="text-xl sm:text-2xl tracking-tight mb-4 sm:mb-6">Versioned JSON output. Pinnable from day one.</h3>
 
-      <div class="grid gap-4 md:grid-cols-2">
-        <p class="text-sm text-[var(--color-mute)]">
-          Every <span class="font-mono">--json</span> invocation emits a record matching
-          <a class="underline decoration-[var(--color-line)] hover:decoration-[var(--color-fg)]" href="/schemas/output-v1.json">schema v1</a>.
-          Adding optional fields is non-breaking; renaming, removing, or changing a field's
-          semantics requires a new schema version. Consumers pin
-          with <span class="font-mono">--require-schema-version=1</span> and fail closed
-          if the binary ever emits a different version.
-        </p>
+      <p class="text-sm text-[var(--color-mute)] mb-6 max-w-3xl">
+        Every <span class="font-mono">--json</span> invocation emits a record matching
+        <a class="underline decoration-[var(--color-line)] hover:decoration-[var(--color-fg)]" href="/schemas/output-v1.json">schema v1</a>.
+        Pin with <span class="font-mono">--require-schema-version=1</span> and fail closed if the
+        binary ever emits a different version.
+      </p>
 
-        <ul class="text-sm space-y-2">
-          <li><span class="font-mono text-[var(--color-accent)]">password</span> — generic credential, named charset</li>
-          <li><span class="font-mono text-[var(--color-accent)]">passphrase</span> — diceware, EFF Large Wordlist</li>
-          <li><span class="font-mono text-[var(--color-accent)]">secret</span> — CSPRNG bytes, base64url (recommended for agents)</li>
-          <li><span class="font-mono text-[var(--color-accent)]">api-key</span> — prefix_base62 (Stripe-style)</li>
-          <li><span class="font-mono text-[var(--color-accent)]">pin</span> — numeric with weak-pattern rejection</li>
-          <li><span class="font-mono text-[var(--color-accent)]">entropy</span> — assess existing credentials</li>
-        </ul>
+      <div class="grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+        {SUBCOMMANDS.map((s) => (
+          <a
+            href={`/${s.slug}/`}
+            class="block border border-[var(--color-line)] rounded-lg p-4 sm:p-5 bg-[var(--color-panel)] hover:border-[var(--color-fg)] transition group"
+          >
+            <div class="flex items-center justify-between mb-2">
+              <span class="font-mono text-sm text-[var(--color-accent)]">{s.slug}</span>
+              <span class="text-[var(--color-mute)] group-hover:text-[var(--color-fg)] transition">→</span>
+            </div>
+            <p class="text-sm text-[var(--color-mute)] leading-snug">{s.intro.split(".")[0]}.</p>
+          </a>
+        ))}
+        <div class="border border-[var(--color-line)] rounded-lg p-4 sm:p-5 bg-[var(--color-panel)] opacity-70">
+          <div class="flex items-center justify-between mb-2">
+            <span class="font-mono text-sm text-[var(--color-accent)]">entropy</span>
+            <span class="text-[10px] font-mono text-[var(--color-mute)]">CLI only</span>
+          </div>
+          <p class="text-sm text-[var(--color-mute)] leading-snug">
+            Estimate the entropy and crack-time of an existing credential. Pipe on stdin to keep it out of process listings.
+          </p>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
Closes part of #13.

Adds five dedicated pages on secretgenerator.org so each subcommand has a route ranked for its own intent:

- `/password/` — "Random password generator (auditable, NIST-aligned)"
- `/passphrase/` — "Diceware passphrase generator (EFF Large Wordlist)"
- `/secret/` — "CSPRNG secret generator (base64url, 256-bit)"
- `/api-key/` — "API key generator (Stripe-style prefix_random)"
- `/pin/` — "Numeric PIN generator with weak-pattern blocklist"

Each page bundles per-subcommand title and meta description for SEO, the live WebAssembly Generator pre-selected on that tab, the relevant defaults table, three CLI examples, code snippets in Python/Node/Rust/Go pinning `--require-schema-version=1`, an FAQ tuned to common LLM-search queries, and cross-links to the other four pages.

Implementation:
- New `web/src/data/subcommands.ts` is the single source of truth.
- New `web/src/pages/[slug].astro` consumes the catalog via `getStaticPaths()` so adding a new subcommand only edits the data file.
- `Generator` accepts an `initial` prop so the home page and per-subcommand pages share the same component.
- The home page now lists all five as clickable cards under `#subcommands` and the nav points to that section.
- `build-llms-txt.mjs` is updated so `llms.txt` links to the dedicated pages instead of the install anchor.

Build verified locally: 6 pages generated, titles and meta descriptions confirmed in the static HTML, cross-link grid correct on every page.