### PR TITLE
feat: sitemap.xml and releases.xml RSS feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,12 @@ __pycache__/
 .pytest_cache/
 .venv/
 python/dist/
+
+# Web build artifacts that are regenerated at deploy time
+web/public/releases.xml
+web/public/og-image.png
+web/public/llms.txt
+web/public/llms-full.txt
+web/public/robots.txt
+web/public/keygen.wasm
+web/public/wasm_exec.js

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from "astro/config";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
+import sitemap from "@astrojs/sitemap";
 
 // https://astro.build/config
 export default defineConfig({
@@ -16,5 +17,30 @@ export default defineConfig({
     plugins: [tailwindcss()],
   },
 
-  integrations: [react()],
+  integrations: [
+    react(),
+    sitemap({
+      // Per-subcommand pages and the homepage are the public surface.
+      // /llms.txt, /llms-full.txt, /robots.txt, /og-image.png are
+      // served as static files and intentionally excluded.
+      filter: (page) => {
+        const u = new URL(page);
+        return (
+          u.pathname === "/" ||
+          /^\/(password|passphrase|secret|api-key|pin)\/$/.test(u.pathname)
+        );
+      },
+      serialize(item) {
+        const u = new URL(item.url);
+        if (u.pathname === "/") {
+          item.priority = 1.0;
+          item.changefreq = "weekly";
+        } else {
+          item.priority = 0.8;
+          item.changefreq = "weekly";
+        }
+        return item;
+      },
+    }),
+  ],
 });

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/react": "^5.0.4",
+        "@astrojs/sitemap": "^3.7.2",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/vite": "^4.2.4",
         "@types/react": "^19.2.14",
@@ -99,6 +100,17 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/sitemap": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.2.tgz",
+      "integrity": "sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "sitemap": "^9.0.0",
+        "stream-replace-string": "^2.0.0",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2532,6 +2544,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2548,6 +2569,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/sax": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
+      "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/unist": {
@@ -2606,6 +2636,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5725,6 +5761,25 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/sitemap": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-9.0.1.tgz",
+      "integrity": "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^24.9.2",
+        "@types/sax": "^1.2.1",
+        "arg": "^5.0.0",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "sitemap": "dist/esm/cli.js"
+      },
+      "engines": {
+        "node": ">=20.19.5",
+        "npm": ">=10.8.2"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
@@ -5755,6 +5810,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stream-replace-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
+      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+      "license": "MIT"
     },
     "node_modules/string.prototype.codepointat": {
       "version": "0.2.1",
@@ -5923,6 +5984,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
       "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicode-trie": {

--- a/web/package.json
+++ b/web/package.json
@@ -8,15 +8,17 @@
   },
   "scripts": {
     "dev": "astro dev",
-    "build": "npm run build:wasm && npm run build:llms && npm run build:og && astro build",
+    "build": "npm run build:wasm && npm run build:llms && npm run build:og && npm run build:rss && astro build",
     "build:wasm": "cd .. && tinygo build -o web/public/keygen.wasm -target wasm -no-debug ./web/wasm && cp \"$(tinygo env TINYGOROOT)/targets/wasm_exec.js\" web/public/wasm_exec.js",
     "build:llms": "node scripts/build-llms-txt.mjs",
     "build:og": "node scripts/build-og-image.mjs",
+    "build:rss": "node scripts/build-releases-rss.mjs",
     "preview": "astro preview",
     "astro": "astro"
   },
   "dependencies": {
     "@astrojs/react": "^5.0.4",
+    "@astrojs/sitemap": "^3.7.2",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/vite": "^4.2.4",
     "@types/react": "^19.2.14",

--- a/web/scripts/build-releases-rss.mjs
+++ b/web/scripts/build-releases-rss.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// Generates web/public/releases.xml — an RSS 2.0 feed of GitHub releases
+// for rafaelperoco/secretgenerator. Subscribers (RSS readers, Datadog
+// release-tracking integrations, security teams watching for CVE
+// disclosures) get updates without polling the GitHub UI.
+//
+// We hit the GitHub REST API anonymously: 60 requests/hour/IP without
+// auth, plenty for a once-per-deploy build. If we ever exceed that,
+// bump GITHUB_TOKEN into the env and the existing fetch call picks it
+// up automatically through the Authorization header check below.
+
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const webRoot = path.resolve(__dirname, "..");
+const publicDir = path.join(webRoot, "public");
+
+const REPO = "rafaelperoco/secretgenerator";
+const SITE = "https://secretgenerator.org";
+const FEED_URL = `${SITE}/releases.xml`;
+const TITLE = "secretgenerator releases";
+const DESCRIPTION =
+  "Release announcements for the auditable random credential generator. Each item links to the signed GitHub release and its release notes.";
+
+main().catch((err) => {
+  console.error("[build-releases-rss] failed:", err.message);
+  // Soft-fail: an empty feed is better than blocking deploy on a
+  // GitHub API hiccup.
+  writeFileSync(path.join(publicDir, "releases.xml"), emptyFeed());
+  console.error("[build-releases-rss] wrote empty placeholder feed");
+});
+
+async function main() {
+  const releases = await fetchReleases();
+  const xml = buildFeed(releases);
+  writeFileSync(path.join(publicDir, "releases.xml"), xml);
+  console.log(`[build-releases-rss] wrote releases.xml (${releases.length} releases)`);
+}
+
+async function fetchReleases() {
+  const url = `https://api.github.com/repos/${REPO}/releases?per_page=50`;
+  const headers = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "secretgenerator-rss-builder",
+  };
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+  }
+  const all = await res.json();
+  // Skip drafts. Pre-releases are kept (they are still real, signed
+  // builds) but flagged in the title.
+  return all.filter((r) => !r.draft);
+}
+
+function buildFeed(releases) {
+  const now = new Date().toUTCString();
+  const items = releases.map(itemXml).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>${escape(TITLE)}</title>
+    <link>${SITE}/</link>
+    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
+    <description>${escape(DESCRIPTION)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${now}</lastBuildDate>
+    <generator>secretgenerator/web/scripts/build-releases-rss.mjs</generator>
+${items}
+  </channel>
+</rss>
+`;
+}
+
+function itemXml(r) {
+  const tag = r.tag_name;
+  const titlePrefix = r.prerelease ? "[pre-release] " : "";
+  const title = `${titlePrefix}${tag}${r.name && r.name !== tag ? ` — ${r.name}` : ""}`;
+  const pub = new Date(r.published_at || r.created_at).toUTCString();
+  const url = r.html_url;
+  // The GitHub release body is markdown. Wrap the whole thing in CDATA
+  // and let the reader render it as plain text — turning it into HTML
+  // here would mean pulling in a markdown renderer for one feature.
+  const body = r.body || "";
+  return `    <item>
+      <title>${escape(title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${pub}</pubDate>
+      <dc:creator>${escape(r.author?.login || "rafaelperoco")}</dc:creator>
+      <description><![CDATA[${body}]]></description>
+    </item>`;
+}
+
+function escape(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function emptyFeed() {
+  const now = new Date().toUTCString();
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escape(TITLE)}</title>
+    <link>${SITE}/</link>
+    <atom:link href="${FEED_URL}" rel="self" type="application/rss+xml" />
+    <description>${escape(DESCRIPTION)}</description>
+    <language>en-us</language>
+    <lastBuildDate>${now}</lastBuildDate>
+  </channel>
+</rss>
+`;
+}

--- a/web/src/layouts/Base.astro
+++ b/web/src/layouts/Base.astro
@@ -52,6 +52,14 @@ const ogImage = new URL("/og-image.png", site).href;
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" href="/favicon.ico" />
 
+    <link rel="sitemap" href="/sitemap-index.xml" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="secretgenerator releases"
+      href="/releases.xml"
+    />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
Closes part of #13.

Two discoverability artifacts on every deploy:

- **Sitemap** at `/sitemap-index.xml` (and `/sitemap-0.xml`), generated by `@astrojs/sitemap`. Indexes the homepage and the five subcommand pages with weekly changefreq and decreasing priority. The `robots.txt` produced by `build-llms-txt.mjs` already advertises this URL — no further wiring needed.
- **RSS feed** at `/releases.xml`, generated from the GitHub Releases API at build time. Soft-fails to an empty channel if the API is unreachable so a hiccup never blocks deploy. Subscribers get release notes the moment the tag pipeline finishes.

The Base layout adds `<link rel="sitemap">` and `<link rel="alternate" type="application/rss+xml">` so feed readers and search engines auto-discover both.

Verified locally: 6 URLs in the sitemap (homepage + 5 subcommand pages), 4 items in releases.xml (v2.0.0 + three alphas), robots.txt still points at `/sitemap-index.xml`.