### PR TITLE
fix(mcp): clear last Dependabot alert (@hono/node-server 2.x)

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -23,12 +23,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.17",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
-      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -47,6 +47,6 @@
   },
   "overrides": {
     "hono": "^4.12.32",
-    "@hono/node-server": "^1.19.17"
+    "@hono/node-server": "^2.0.12"
   }
 }


### PR DESCRIPTION
## Summary
Overrides transitive `@hono/node-server` to **2.0.12**, clearing Dependabot alert #34 (medium, Windows serve-static path traversal).

`npm audit` in `/mcp` is now **0 vulnerabilities**. Smoke test still passes (stdio tools; we do not use serve-static).

## Test plan
- [x] `npm install` + `npm audit` → 0
- [x] `node dist/smoke.js` OK
- [ ] CI green